### PR TITLE
fix: _pinned flag not persisted in SQLite, causing incorrect compaction in resumed sessions (closes #1)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -352,10 +352,12 @@ export class Agent {
       }, threadId);
 
       for (const tr of pendingToolResults) {
+        const isSkillTool = pendingToolCalls.some(tc => tc.id === tr.toolCallId && tc.name === SKILL_TOOL_NAME);
         this.conversations.appendMessage({
           role: 'tool' as MessageRole,
           content: tr.content,
           toolCallId: tr.toolCallId,
+          pinned: isSkillTool || undefined,
           createdAt: now - 1,
         }, threadId);
       }

--- a/src/core/context-builder.ts
+++ b/src/core/context-builder.ts
@@ -140,6 +140,11 @@ function chatMessageToLLM(msg: ChatMessage): LLMMessage {
     result.tool_call_id = msg.toolCallId;
   }
 
+  // Propagate pinned status so autocompact/snipCompact honour it in resumed sessions.
+  if (msg.pinned) {
+    (result as unknown as Record<string, unknown>)._pinned = true;
+  }
+
   return result;
 }
 

--- a/tests/unit/agent-extended.test.ts
+++ b/tests/unit/agent-extended.test.ts
@@ -147,4 +147,60 @@ describe('Agent — extended API (divergence fixes)', () => {
     const body = JSON.parse((chatCall![1] as RequestInit).body as string);
     expect(body.response_format).toEqual({ type: 'json_object' });
   });
+
+  it('skill tool result should be saved with pinned=true (issue #1)', async () => {
+    // SSE round 1: LLM calls the Skill tool
+    const round1 = [
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc-skill-1","type":"function","function":{"name":"Skill","arguments":""}}]},"index":0}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"skill\\":\\"test-skill\\"}"}}]},"index":0}]}\n\n',
+      'data: {"choices":[{"finish_reason":"tool_calls","index":0}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}\n\n',
+    ].join('');
+
+    // SSE round 2: LLM responds with final text
+    const round2 = [
+      'data: {"choices":[{"delta":{"content":"Done"},"index":0}]}\n\n',
+      'data: {"choices":[{"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}}\n\n',
+    ].join('');
+
+    let fetchCall = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/embeddings')) {
+        return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+      }
+      fetchCall++;
+      const data = fetchCall === 1 ? round1 : round2;
+      return new Response(
+        new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode(data)); c.close(); } }),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    });
+
+    // Custom store to observe what gets persisted
+    const appended: Array<{ role: string; content: string; pinned?: boolean; toolCallId?: string }> = [];
+    const customStore = {
+      appendMessage(msg: { role: string; content: string; pinned?: boolean; toolCallId?: string }, _threadId: string) {
+        appended.push({ role: msg.role, content: String(msg.content), pinned: msg.pinned, toolCallId: msg.toolCallId });
+      },
+      listThread: () => [],
+      listPinned: () => [],
+      clearThread: () => {},
+    };
+
+    const agent = Agent.create({
+      apiKey: 'test-key',
+      memory: { enabled: false },
+      knowledge: { enabled: false },
+      conversation: { store: customStore as never },
+    });
+
+    agent.addSkill({ name: 'test-skill', description: 'test', instructions: 'Do test' });
+
+    await agent.chat('invoke skill');
+
+    const toolResult = appended.find(m => m.role === 'tool' && m.toolCallId === 'tc-skill-1');
+    expect(toolResult).toBeDefined();
+    // Skill tool results MUST be saved as pinned so they survive compaction in resumed sessions
+    expect(toolResult!.pinned).toBe(true);
+  });
 });

--- a/tests/unit/core/context-builder.test.ts
+++ b/tests/unit/core/context-builder.test.ts
@@ -195,4 +195,28 @@ describe('buildContext', () => {
     // Total should be 3 (merged user + assistant + user), not 4
     expect(result.messages.length).toBe(3);
   });
+
+  it('should propagate _pinned flag from pinned ChatMessage to LLMMessage (issue #1)', () => {
+    // A skill tool result is stored in SQLite with pinned=true.
+    // When loaded back and converted to LLMMessage, _pinned must be set so that
+    // autocompact / snipCompact honour it in resumed sessions.
+    const pinnedTool: ChatMessage = { role: 'tool', content: 'skill output', pinned: true, toolCallId: 'tc1', createdAt: 1 };
+    const unpinnedTool: ChatMessage = { role: 'tool', content: 'regular output', pinned: false, toolCallId: 'tc2', createdAt: 2 };
+
+    const result = buildContext({
+      systemPrompt: '',
+      injections: [],
+      history: [pinnedTool, unpinnedTool],
+      maxTokens: 10000,
+      reserveTokens: 0,
+      maxPinnedMessages: 20,
+    });
+
+    const llmPinned = result.messages.find(m => m.tool_call_id === 'tc1');
+    const llmUnpinned = result.messages.find(m => m.tool_call_id === 'tc2');
+
+    expect(llmPinned).toBeDefined();
+    expect((llmPinned as unknown as Record<string, unknown>)._pinned).toBe(true);
+    expect((llmUnpinned as unknown as Record<string, unknown>)._pinned).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Issue
Closes #1

## Problema
Skill tool results eram marcados com `_pinned = true` apenas na memória (`LLMMessage` em `react-loop.ts`), mas dois pontos do pipeline não persistiam esse estado:

1. **`agent.ts`**: ao salvar tool results no SQLite, não verificava se o tool call era do `SKILL_TOOL_NAME`, então `pinned` ficava `undefined` na `ChatMessage` armazenada.
2. **`context-builder.ts` (`chatMessageToLLM`)**: ao carregar uma sessão do SQLite, mensagens com `pinned: true` eram convertidas para `LLMMessage` sem `_pinned: true`, tornando-as invisíveis para `autocompact` e `snipCompact`.

Resultado: ao retomar uma sessão longa, resultados de skill tools de sessões anteriores podiam ser compactados/removidos incorretamente.

## Abordagem TDD
- Teste em: `tests/unit/core/context-builder.test.ts` + `tests/unit/agent-extended.test.ts`
- Falha antes do fix (red): `_pinned` era `undefined` em ambos os casos
- Implementação mínima em: `src/core/context-builder.ts`, `src/agent.ts`
- Suíte completa: verde (o único failure pré-existente é `teams-bot/agent-factory.test.ts` que requer `dist/` não construído)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_