### PR TITLE
fix: sanitize __ in MCP server/tool names to prevent namespace collision (closes #2)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -280,7 +280,9 @@ export class MCPAdapter {
   }
 
   private convertTool(serverName: string, mcpTool: MCPToolDef, client: MCPClient, config: MCPConnectionConfig): AgentTool {
-    const namespacedName = `mcp__${serverName}__${mcpTool.name}`;
+    const safeServerName = serverName.replace(/__/g, '_');
+    const safeToolName = mcpTool.name.replace(/__/g, '_');
+    const namespacedName = `mcp__${safeServerName}__${safeToolName}`;
     const parameters = jsonSchemaToZod(mcpTool.inputSchema as Record<string, unknown> | undefined);
     const isolateErrors = config.isolateErrors ?? true;
     const timeout = config.timeout ?? 30_000;

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -674,4 +674,39 @@ describe('MCPAdapter', () => {
       expect(tools).toHaveLength(2);
     });
   });
+
+  describe('namespace collision (issue #2)', () => {
+    it('should sanitize __ in serverName to prevent namespace collision', async () => {
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [{ name: 'baz', description: 'tool', inputSchema: { type: 'object', properties: {} } }],
+      });
+
+      // server "foo__bar" + tool "baz" must NOT produce same name as server "foo" + tool "bar__baz"
+      const tools = await adapter.connect({
+        name: 'foo__bar',
+        transport: 'stdio',
+        command: 'node',
+        args: ['s.js'],
+      });
+
+      // After sanitization: mcp__foo_bar__baz (single underscore replaces __)
+      expect(tools[0]!.name).toBe('mcp__foo_bar__baz');
+    });
+
+    it('should sanitize __ in toolName to prevent namespace collision', async () => {
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [{ name: 'bar__baz', description: 'tool', inputSchema: { type: 'object', properties: {} } }],
+      });
+
+      const tools = await adapter.connect({
+        name: 'foo',
+        transport: 'stdio',
+        command: 'node',
+        args: ['s.js'],
+      });
+
+      // After sanitization: mcp__foo__bar_baz (__ in tool name collapsed to _)
+      expect(tools[0]!.name).toBe('mcp__foo__bar_baz');
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #2

## Problema
O namespace de ferramentas MCP era construído por concatenação simples: `mcp__${serverName}__${toolName}`. O separador `__` não era sanitizado, então:
- Servidor `"foo__bar"` + ferramenta `"baz"` → `mcp__foo__bar__baz`
- Servidor `"foo"` + ferramenta `"bar__baz"` → `mcp__foo__bar__baz`

Colisão perfeita: um servidor MCP não confiável poderia fazer shadow de uma ferramenta legítima.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts` (describe `namespace collision (issue #2)`)
- Falha antes do fix (red): nomes colisionantes eram produzidos sem sanitização
- Implementação mínima em: `src/tools/mcp-adapter.ts:283-285` — `replace(/__/g, '_')` em serverName e toolName
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_