### PR TITLE
fix: eliminate double JSON.parse in StreamingToolExecutor (closes #3)

### DIFF
--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -20,6 +20,7 @@ interface TrackedTool {
   id: string;
   name: string;
   args: string;
+  parsedArgs: unknown;
   isSafe: boolean;
   status: ToolStatus;
   result?: AgentToolResult;
@@ -59,7 +60,7 @@ export class StreamingToolExecutor {
         : toolDef.isConcurrencySafe === true
       : false;
 
-    const tracked: TrackedTool = { id, name, args, isSafe, status: 'queued', progressEvents: [] };
+    const tracked: TrackedTool = { id, name, args, parsedArgs, isSafe, status: 'queued', progressEvents: [] };
     this.tools.push(tracked);
     void this.processQueue();
   }
@@ -160,9 +161,7 @@ export class StreamingToolExecutor {
 
   private async executeTool(tracked: TrackedTool): Promise<void> {
     const start = Date.now();
-
-    let parsedArgs: unknown;
-    try { parsedArgs = JSON.parse(tracked.args); } catch { parsedArgs = {}; }
+    const { parsedArgs } = tracked;
 
     // Build progress callback that accumulates events
     const onProgress = (data: Record<string, unknown>) => {

--- a/tests/unit/core/streaming-tool-executor.test.ts
+++ b/tests/unit/core/streaming-tool-executor.test.ts
@@ -270,6 +270,46 @@ describe('StreamingToolExecutor', () => {
     expect(results).toHaveLength(2);
   });
 
+  it('should parse tool args exactly once per tool call (issue #3)', async () => {
+    // Double JSON.parse wastes CPU and creates inconsistency when JSON is malformed.
+    // parsedArgs computed in addTool() must be reused in executeTool() without re-parsing.
+    const executor = new ToolExecutor();
+    const receivedArgs: unknown[] = [];
+
+    executor.register(createTool({
+      name: 'probe',
+      parameters: z.object({ input: z.string() }),
+      isConcurrencySafe: (args: unknown) => {
+        receivedArgs.push(args);
+        return true;
+      },
+      execute: vi.fn().mockImplementation((args: unknown) => {
+        receivedArgs.push(args);
+        return Promise.resolve('ok');
+      }),
+    }));
+
+    let parseCount = 0;
+    const origParse = JSON.parse;
+    vi.spyOn(JSON, 'parse').mockImplementation((text: string) => {
+      parseCount++;
+      return origParse(text);
+    });
+
+    const streaming = new StreamingToolExecutor(executor);
+    streaming.addTool('c1', 'probe', '{"input":"hello"}');
+    for await (const _ of streaming.getRemainingResults()) { /* drain */ }
+
+    vi.restoreAllMocks();
+
+    // Should parse args only once — not twice (addTool + executeTool)
+    expect(parseCount).toBe(1);
+    // Both isConcurrencySafe and execute should receive the same parsed object
+    expect(receivedArgs).toHaveLength(2);
+    expect(receivedArgs[0]).toEqual({ input: 'hello' });
+    expect(receivedArgs[1]).toEqual({ input: 'hello' });
+  });
+
   it('getCompletedResults should be non-blocking and yield only finished tools', async () => {
     const executor = new ToolExecutor();
     executor.register(createTool({


### PR DESCRIPTION
## Issue
Closes #3

## Problema
`StreamingToolExecutor.addTool()` e `executeTool()` parseavam `args` de forma independente com `JSON.parse`. O resultado do primeiro parse era descartado e o string bruto re-parseado na execução. Quando JSON era inválido, o fallback `{}` era usado silenciosamente sem nenhum aviso, e a decisão de concorrência (`isConcurrencySafe`) e a execução real podiam em teoria divergir em edge cases.

## Abordagem TDD
- Teste em: `tests/unit/core/streaming-tool-executor.test.ts` ("should parse tool args exactly once")
- Falha antes do fix (red): `JSON.parse` era chamado 2x por tool call
- Implementação mínima em: `src/core/streaming-tool-executor.ts` — `parsedArgs` adicionado ao `TrackedTool`, calculado uma vez em `addTool` e reutilizado em `executeTool`
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_