### PR TITLE
fix: validate role field when deserializing ChatMessage from SQLite (closes #5)

### DIFF
--- a/src/storage/sqlite-conversation-store.ts
+++ b/src/storage/sqlite-conversation-store.ts
@@ -46,7 +46,13 @@ export class SQLiteConversationStore implements ConversationStore {
   }
 }
 
+const VALID_ROLES = new Set<string>(['user', 'assistant', 'system', 'tool']);
+
 function rowToMessage(row: ConversationRow): ChatMessage {
+  if (!VALID_ROLES.has(row.role)) {
+    throw new Error(`Invalid message role in database: "${row.role}"`);
+  }
+
   let content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
   try {
     const parsed = JSON.parse(row.content);

--- a/tests/unit/storage/sqlite-conversation-store.test.ts
+++ b/tests/unit/storage/sqlite-conversation-store.test.ts
@@ -96,6 +96,17 @@ describe('SQLiteConversationStore', () => {
     expect(store.listThread('nonexistent')).toHaveLength(0);
   });
 
+  it('should throw on invalid role value from database (issue #5)', () => {
+    // If the SQLite file is manually edited or corrupted, an invalid role must be
+    // caught at the storage boundary — not propagated silently to the LLM layer.
+    database.db.prepare(`
+      INSERT INTO conversations (thread_id, role, content, tool_calls, tool_call_id, pinned, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('t-badrole', 'INVALID_ROLE', 'hello', null, null, 0, Date.now());
+
+    expect(() => store.listThread('t-badrole')).toThrow(/Invalid message role/);
+  });
+
   it('should order messages by created_at', () => {
     store.appendMessage({ ...msg('user', 'first'), createdAt: 100 }, 'thread-1');
     store.appendMessage({ ...msg('user', 'third'), createdAt: 300 }, 'thread-1');


### PR DESCRIPTION
## Issue
Closes #5

## Problema
`rowToMessage` em `sqlite-conversation-store.ts` fazia cast direto `row.role as ChatMessage['role']` sem validar que o valor estava no conjunto permitido (`user | assistant | system | tool`). Um banco de dados corrompido ou editado manualmente com role inválido propagava o valor silenciosamente até a camada de LLM, causando erros difíceis de diagnosticar.

## Abordagem TDD
- Teste em: `tests/unit/storage/sqlite-conversation-store.test.ts` ("should throw on invalid role value")
- Falha antes do fix (red): `listThread` não lançava erro para roles inválidos
- Implementação mínima em: `src/storage/sqlite-conversation-store.ts` — `VALID_ROLES` Set + validação no início de `rowToMessage`
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_