### PR TITLE
fix: sanitize LLM HTTP error body to prevent PII leakage in exceptions (closes #8)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -19,6 +19,18 @@ function isRetryableStatus(status: number): boolean {
   return status === 429 || status >= 500;
 }
 
+const MAX_ERROR_BODY = 500;
+
+function sanitizeErrorBody(text: string): string {
+  const truncated = text.length > MAX_ERROR_BODY ? `${text.slice(0, MAX_ERROR_BODY)}... [truncated]` : text;
+  try {
+    const parsed = JSON.parse(truncated);
+    const msg = parsed?.error?.message ?? parsed?.message;
+    if (typeof msg === 'string') return msg.slice(0, MAX_ERROR_BODY);
+  } catch { /* not JSON — return truncated plain text */ }
+  return truncated;
+}
+
 /**
  * LLMClient performs automatic retry on RetryableError (HTTP 429 / 5xx).
  * Non-idempotent POST requests to /chat/completions and /embeddings are retried
@@ -190,7 +202,7 @@ export class LLMClient {
         throw new RetryableError(`LLM API error: ${response.status}`, retryAfterMs);
       }
       const text = await response.text().catch(() => '');
-      throw new Error(`LLM API error ${response.status}: ${text}`);
+      throw new Error(`LLM API error ${response.status}: ${sanitizeErrorBody(text)}`);
     }
 
     return response;

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -105,6 +105,41 @@ describe('LLMClient', () => {
         messages: [{ role: 'user', content: 'Hi' }],
       })).rejects.toThrow('LLM API error 400');
     });
+
+    it('should truncate large error bodies to avoid leaking conversation content (issue #8)', async () => {
+      // Simulate an API that echoes request content in error messages (e.g. OpenRouter)
+      const sensitiveContent = 'SENSITIVE_USER_DATA: ' + 'x'.repeat(1000);
+      mockFetch(new Response(sensitiveContent, { status: 400 }));
+
+      let errorMessage = '';
+      try {
+        await client.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+      } catch (e) {
+        errorMessage = (e as Error).message;
+      }
+
+      // Error must not include the full 1000-char sensitive body
+      expect(errorMessage.length).toBeLessThan(600);
+      expect(errorMessage).not.toContain('x'.repeat(600));
+    });
+
+    it('should extract structured error message from JSON error body (issue #8)', async () => {
+      const jsonBody = JSON.stringify({
+        error: { message: 'Model context limit exceeded', code: 400 },
+      });
+      mockFetch(new Response(jsonBody, { status: 400 }));
+
+      let errorMessage = '';
+      try {
+        await client.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+      } catch (e) {
+        errorMessage = (e as Error).message;
+      }
+
+      // Should extract the structured message, not include raw JSON envelope
+      expect(errorMessage).toContain('Model context limit exceeded');
+      expect(errorMessage).not.toContain('"error"');
+    });
   });
 
   describe('streamChat()', () => {


### PR DESCRIPTION
## Issue
Closes #8

## Problema
`llm-client.ts:192-193` incluía o body bruto da resposta HTTP de erro na mensagem da exceção. Provedores como OpenRouter podem ecoar conteúdo da conversa em mensagens de erro 400, expondo PII em logs de aplicação.

## Abordagem TDD
- Testes em: `tests/unit/llm/llm-client.test.ts` (2 novos casos)
- Falha antes do fix (red): body completo (1000+ chars) era incluído na exceção; JSON envelope não era extraído
- Implementação mínima em: `src/llm/llm-client.ts` — função `sanitizeErrorBody()` que trunca em 500 chars e extrai `error.message` / `message` de JSON estruturado
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (CWE-209 / OWASP A09)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_