### PR TITLE
fix: add min/max bounds to Bash tool timeout parameter (closes #9)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -25,7 +25,13 @@ const MAX_OUTPUT = 500_000; // 500KB
 
 const BashParams = z.object({
   command: z.string().describe('Shell command to execute'),
-  timeout: z.number().optional().describe('Timeout in milliseconds. Default: 120000 (2 minutes).'),
+  timeout: z
+    .number()
+    .int()
+    .min(1, 'Timeout must be at least 1ms')
+    .max(300_000, 'Timeout cannot exceed 5 minutes (300000ms)')
+    .optional()
+    .describe('Timeout in milliseconds. Default: 120000 (2 minutes). Max: 300000 (5 minutes).'),
 });
 
 export function createBashTool(): AgentTool {
@@ -37,7 +43,7 @@ export function createBashTool(): AgentTool {
     timeoutMs: DEFAULT_TIMEOUT,
 
     async execute(rawArgs: unknown, signal: AbortSignal) {
-      const { command, timeout } = rawArgs as z.infer<typeof BashParams>;
+      const { command, timeout } = BashParams.parse(rawArgs);
       const effectiveTimeout = timeout ?? DEFAULT_TIMEOUT;
 
       return new Promise<string | { content: string; isError?: boolean }>((resolve) => {

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -45,4 +45,35 @@ describe('builtin/bash', () => {
     expect(content).toContain('line1');
     expect(content).toContain('line2');
   });
+
+  describe('timeout parameter bounds (issue #9)', () => {
+    it('should reject timeout=0 (would disable exec timeout)', async () => {
+      const tool = createBashTool();
+      // timeout=0 is interpreted by Node exec as "no timeout" — must be rejected
+      await expect(
+        tool.execute({ command: 'echo ok', timeout: 0 }, signal)
+      ).rejects.toThrow();
+    });
+
+    it('should reject negative timeout values', async () => {
+      const tool = createBashTool();
+      await expect(
+        tool.execute({ command: 'echo ok', timeout: -1000 }, signal)
+      ).rejects.toThrow();
+    });
+
+    it('should reject timeout exceeding 300000ms (5 minutes)', async () => {
+      const tool = createBashTool();
+      await expect(
+        tool.execute({ command: 'echo ok', timeout: 301_000 }, signal)
+      ).rejects.toThrow();
+    });
+
+    it('should accept valid timeout within bounds', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo ok', timeout: 5000 }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('ok');
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #9

## Problema
O parâmetro `timeout` da ferramenta Bash aceitava qualquer número incluindo `0`, negativos e valores > 2h. `timeout=0` é interpretado pelo `child_process.exec` como "sem timeout" (processo pode rodar indefinidamente se o AbortSignal falhar). Valores muito altos removiam na prática o timeout de 2 minutos ao nível do subprocess.

## Abordagem TDD
- Testes em: `tests/unit/tools/builtin/bash.test.ts` (describe "timeout parameter bounds")
- Falha antes do fix (red): `timeout=0` e `timeout=301000` eram aceitos e executavam o comando
- Implementação mínima em: `src/tools/builtin/bash.ts` — `.int().min(1).max(300_000)` no schema Zod + `BashParams.parse(rawArgs)` em `execute` para garantir validação mesmo quando chamado diretamente
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma. O schema Zod é parte da interface pública da ferramenta (não um config de CI/regra arquitetural).

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_