### PR TITLE
fix: reject ReDoS-prone patterns in createGrepTool (issue #7)

### DIFF
--- a/src/tools/builtin/grep.ts
+++ b/src/tools/builtin/grep.ts
@@ -49,6 +49,13 @@ export function createGrepTool(): AgentTool {
       const baseDir = searchPath || process.cwd();
       const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
 
+      // Reject patterns that can cause catastrophic backtracking (ReDoS).
+      // Catches: quantified groups (a+)+, consecutive quantifiers a+*, quantified classes [a-z]*.
+      const REDOS_RISK = /(\(.*[+*?]\)|[+*?]{2,}|\[\^?.*\]\*)/;
+      if (REDOS_RISK.test(pattern)) {
+        return { content: 'Pattern too complex — potential ReDoS risk', isError: true };
+      }
+
       let regex: RegExp;
       try {
         regex = new RegExp(pattern, 'g');

--- a/tests/unit/tools/builtin/grep.test.ts
+++ b/tests/unit/tools/builtin/grep.test.ts
@@ -57,4 +57,42 @@ describe('builtin/grep', () => {
     const lines = content.split('\n').filter(l => l.includes(':'));
     expect(lines.length).toBeLessThanOrEqual(2); // 1 match + possible context
   });
+
+  describe('ReDoS protection (issue #7)', () => {
+    it('should reject patterns with nested quantifiers like (a+)+', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: '(a+)+b', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/complex|ReDoS/i);
+    });
+
+    it('should reject patterns with consecutive quantifiers like a+*', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: 'a+*', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('should reject patterns with quantified character classes like [a-z]*+', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: '[a-z]*+', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('should still accept safe patterns', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: 'function', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+
+    it('should still accept patterns with single quantifiers', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: 'hel+o', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `REDOS_RISK` check in `createGrepTool` before compiling user-supplied regex patterns
- Rejects patterns with nested quantifiers `(a+)+`, consecutive quantifiers `a+*`, and quantified character classes `[a-z]*`
- Returns `{ content: '...', isError: true }` immediately so callers surface the refusal without running the regex engine
- Adds 5 new tests (RED → GREEN) covering dangerous patterns and confirming safe patterns still work

## Test plan

- [x] `(a+)+b` rejected with `isError: true` and message matching `/complex|ReDoS/i`
- [x] `a+*` rejected (already caught by `new RegExp()`, now also by REDOS_RISK)
- [x] `[a-z]*+` rejected
- [x] `function` (safe) still accepted
- [x] `hel+o` (single quantifier, safe) still accepted
- [x] Full suite: 708 tests pass, 0 regressions

https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALdD77zH9CqA1pRwYUKCyk)_