### PR TITLE
ci: serialize release workflow and sync with main before bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -88,6 +92,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Sync with the latest main before bumping so we never start from a
+          # stale SHA when multiple PRs are merged in quick succession.
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
 
           NEW_VERSION=$(npm version ${{ steps.bump.outputs.type }} --no-git-tag-version)
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Add workflow-level `concurrency: release-publish` (queue, no cancel) so concurrent merges to main don't race on the version bump.
- Sync with `origin/main` (`fetch` + `checkout main` + `reset --hard`) before `npm version`, so each run bumps from the current tip regardless of the triggering SHA.

Fixes the `non-fast-forward` push failure observed in Release & Publish #22.

## Test plan
- [ ] Merge this PR and confirm the Release & Publish run completes (push + npm publish + GitHub release).
- [ ] Merge a second PR shortly after and confirm it queues behind the first instead of racing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)