### PR TITLE
chore: add repository metadata for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DouglasPrado/agentx-sdk.git"
+  },
+  "homepage": "https://github.com/DouglasPrado/agentx-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/DouglasPrado/agentx-sdk/issues"
+  },
   "dependencies": {
     "better-sqlite3": "^11.0.0",
     "zod": "^3.23.0",


### PR DESCRIPTION
## Summary
- Add `repository`, `homepage`, and `bugs` fields to `package.json` pointing at `DouglasPrado/agentx-sdk`.
- Required for `npm publish --provenance` to validate the sigstore bundle (E422 otherwise — the prior v0.5.2 publish failed for this reason).

This commit was originally part of #19 but was lost when that PR was merged before the second push landed.

## Test plan
- [ ] Merge and confirm Release & Publish run completes through `npm publish` and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)