### PR TITLE
fix: bloqueia SSRF via redirect e IPv6 privado em WebFetch (closes #21)

### DIFF
--- a/src/tools/builtin/web-fetch.ts
+++ b/src/tools/builtin/web-fetch.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
 
 const DEFAULT_MAX_CHARS = 50_000;
+const MAX_REDIRECT_HOPS = 5;
 
 /** Validate URL against SSRF attack vectors. Returns null if safe, error message if blocked. */
 function validateFetchUrl(rawUrl: string): string | null {
@@ -33,6 +34,20 @@ function validateFetchUrl(rawUrl: string): string | null {
     if (a === 172 && b >= 16 && b <= 31) return 'Blocked private range 172.16.0.0/12';
     if (a === 169 && b === 254) return 'Blocked link-local range (cloud metadata)';
     if (a === 0) return 'Blocked 0.0.0.0/8';
+  }
+
+  // IPv6 checks — strip brackets for pattern matching
+  const ipv6Bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+
+  // Link-local: fe80::/10 (fe80 – febf)
+  if (/^fe[89ab]/i.test(ipv6Bare)) return 'Blocked IPv6 link-local address (fe80::/10)';
+  // ULA (unique local): fc00::/7 (fc and fd prefixes)
+  if (/^f[cd]/i.test(ipv6Bare)) return 'Blocked IPv6 private range (fc00::/7)';
+  // IPv4-mapped: ::ffff:a.b.c.d — re-validate the embedded IPv4 address
+  const ipv4MappedMatch = ipv6Bare.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (ipv4MappedMatch) {
+    const embeddedResult = validateFetchUrl(`http://${ipv4MappedMatch[1]}/`);
+    if (embeddedResult) return `Blocked IPv4-mapped IPv6: ${embeddedResult}`;
   }
 
   return null;
@@ -74,11 +89,41 @@ export function createWebFetchTool(): AgentTool {
       if (blocked) return { content: blocked, isError: true };
 
       try {
-        const response = await fetch(url, {
-          signal,
-          headers: { 'User-Agent': 'AgentX-SDK/1.0' },
-          redirect: 'follow',
-        });
+        // Follow redirects manually so each hop is validated against SSRF rules.
+        let currentUrl = url;
+        let response!: Response;
+
+        for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+          if (hop === MAX_REDIRECT_HOPS) {
+            return { content: `SSRF check: too many redirects (>${MAX_REDIRECT_HOPS})`, isError: true };
+          }
+
+          response = await fetch(currentUrl, {
+            signal,
+            headers: { 'User-Agent': 'AgentX-SDK/1.0' },
+            redirect: 'manual',
+          });
+
+          if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get('location');
+            if (!location) {
+              return { content: 'Redirect without Location header', isError: true };
+            }
+            let nextUrl: string;
+            try {
+              nextUrl = new URL(location, currentUrl).href;
+            } catch {
+              return { content: `Redirect blocked: invalid URL ${location}`, isError: true };
+            }
+            const redirectBlocked = validateFetchUrl(nextUrl);
+            if (redirectBlocked) {
+              return { content: `Redirect blocked: ${redirectBlocked}`, isError: true };
+            }
+            currentUrl = nextUrl;
+            continue;
+          }
+          break;
+        }
 
         if (!response.ok) {
           return { content: `HTTP ${response.status}: ${response.statusText}`, isError: true };

--- a/tests/unit/tools/builtin/web-fetch.test.ts
+++ b/tests/unit/tools/builtin/web-fetch.test.ts
@@ -97,5 +97,70 @@ describe('builtin/web-fetch', () => {
         expect(parsed.isError, `should block ${url}`).toBe(true);
       }
     });
+
+    // --- issue #21: redirect bypass and IPv6 private ranges ---
+
+    it('blocks redirect to internal IPv4 (SSRF via redirect)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { Location: 'http://169.254.169.254/latest/meta-data/' },
+        }),
+      );
+      const result = await tool.execute({ url: 'https://example.com/redirect' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/[Rr]edirect|[Bb]locked/);
+    });
+
+    it('blocks redirect to private range 10.x.x.x (SSRF via redirect)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'http://10.0.0.1/internal' },
+        }),
+      );
+      const result = await tool.execute({ url: 'https://example.com/redir2' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks IPv6 ULA addresses (fc00::/7)', async () => {
+      for (const url of ['http://[fc00::1]/', 'http://[fd12:3456:789a::1]/']) {
+        const result = await tool.execute({ url }, signal);
+        const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+        expect(parsed.isError, `should block ${url}`).toBe(true);
+      }
+    });
+
+    it('blocks IPv6 link-local addresses (fe80::/10)', async () => {
+      const result = await tool.execute({ url: 'http://[fe80::1%25eth0]/' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks IPv4-mapped IPv6 for private ranges', async () => {
+      for (const url of ['http://[::ffff:10.0.0.1]/', 'http://[::ffff:192.168.1.1]/']) {
+        const result = await tool.execute({ url }, signal);
+        const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+        expect(parsed.isError, `should block ${url}`).toBe(true);
+      }
+    });
+
+    it('allows valid redirect to safe HTTPS URL', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 301,
+            headers: { Location: 'https://example.com/final' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response('safe content', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+        );
+      const result = await tool.execute({ url: 'https://example.com/old' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('safe content');
+    });
   });
 });


### PR DESCRIPTION
## Issue
Closes #21

## Problema
`WebFetch` usava `redirect: 'follow'` sem revalidar o destino final do redirect contra `validateFetchUrl()`. Um servidor público poderia redirecionar para `169.254.169.254` (IMDS da AWS/GCP) ou qualquer IP interno. Adicionalmente, IPv6 privados (fc00::/7, fe80::/10) e IPv4 mapeados em IPv6 (`::ffff:10.x.x.x`) não eram bloqueados.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/web-fetch.test.ts`
- Falha antes do fix (red): redirect para `169.254.169.254` retornava `HTTP 301:` sem mensagem de bloqueio; redirect para safe URL não era seguido
- Implementação mínima em: `src/tools/builtin/web-fetch.ts`
  - Troca `redirect:'follow'` por `redirect:'manual'` com loop de no máximo 5 hops, validando cada `Location` header via `validateFetchUrl()` antes de seguir
  - Adiciona bloqueio de IPv6 link-local (fe80::/10), ULA (fc00::/7) e IPv4-mapeado (`::ffff:`), re-validando o endereço IPv4 embutido
- Suíte completa: 726 testes passam

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_