### PR TITLE
fix: path traversal bloqueado em Write e Edit via workingDir (closes #22)

### DIFF
--- a/src/tools/builtin/file-edit.ts
+++ b/src/tools/builtin/file-edit.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
+import { assertSafePath } from './path-guard.js';
 
 const FileEditParams = z.object({
   file_path: z.string().describe('Absolute path to the file to edit'),
@@ -9,7 +10,7 @@ const FileEditParams = z.object({
   replace_all: z.boolean().optional().describe('Replace all occurrences. Default: false (must be unique).'),
 });
 
-export function createFileEditTool(): AgentTool {
+export function createFileEditTool(workingDir?: string): AgentTool {
   return {
     name: 'Edit',
     description: 'Find and replace exact strings in a file. By default, old_string must be unique in the file.',
@@ -18,6 +19,14 @@ export function createFileEditTool(): AgentTool {
 
     async execute(rawArgs: unknown) {
       const { file_path, old_string, new_string, replace_all } = rawArgs as z.infer<typeof FileEditParams>;
+
+      if (workingDir) {
+        try {
+          assertSafePath(file_path, workingDir);
+        } catch (error) {
+          return { content: (error as Error).message, isError: true };
+        }
+      }
 
       let content: string;
       try {

--- a/src/tools/builtin/file-write.ts
+++ b/src/tools/builtin/file-write.ts
@@ -2,13 +2,14 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
+import { assertSafePath } from './path-guard.js';
 
 const FileWriteParams = z.object({
   file_path: z.string().describe('Absolute path to the file to write'),
   content: z.string().describe('Content to write to the file'),
 });
 
-export function createFileWriteTool(): AgentTool {
+export function createFileWriteTool(workingDir?: string): AgentTool {
   return {
     name: 'Write',
     description: 'Write content to a file. Creates parent directories if needed. Overwrites existing files.',
@@ -18,6 +19,14 @@ export function createFileWriteTool(): AgentTool {
 
     async execute(rawArgs: unknown) {
       const { file_path, content } = rawArgs as z.infer<typeof FileWriteParams>;
+
+      if (workingDir) {
+        try {
+          assertSafePath(file_path, workingDir);
+        } catch (error) {
+          return { content: (error as Error).message, isError: true };
+        }
+      }
 
       try {
         await mkdir(dirname(file_path), { recursive: true });

--- a/src/tools/builtin/path-guard.ts
+++ b/src/tools/builtin/path-guard.ts
@@ -1,0 +1,13 @@
+import { resolve, relative, isAbsolute } from 'node:path';
+
+/**
+ * Asserts that filePath is contained within rootDir.
+ * Throws if the resolved path escapes the root (path traversal).
+ */
+export function assertSafePath(filePath: string, rootDir: string): void {
+  const abs = resolve(filePath);
+  const rel = relative(rootDir, abs);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`Path traversal blocked: "${filePath}" is outside working directory "${rootDir}"`);
+  }
+}

--- a/tests/unit/tools/builtin/file-edit.test.ts
+++ b/tests/unit/tools/builtin/file-edit.test.ts
@@ -88,4 +88,51 @@ describe('builtin/file-edit', () => {
     const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
     expect(parsed.isError).toBe(true);
   });
+
+  // --- issue #22: path traversal protection ---
+
+  it('blocks path traversal outside workingDir', async () => {
+    const tool = createFileEditTool(tempDir);
+    const result = await tool.execute({
+      file_path: join(tempDir, '..', 'code.ts'),
+      old_string: 'x',
+      new_string: 'y',
+    }, signal);
+    const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+    expect(parsed.isError).toBe(true);
+    expect(parsed.content).toMatch(/[Tt]raversal|[Bb]locked|outside/);
+  });
+
+  it('blocks absolute path outside workingDir', async () => {
+    const tool = createFileEditTool(tempDir);
+    const result = await tool.execute({
+      file_path: '/etc/hosts',
+      old_string: 'localhost',
+      new_string: 'evil',
+    }, signal);
+    const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+    expect(parsed.isError).toBe(true);
+  });
+
+  it('allows edit inside workingDir when workingDir is set', async () => {
+    const tool = createFileEditTool(tempDir);
+    const result = await tool.execute({
+      file_path: join(tempDir, 'code.ts'),
+      old_string: 'return "world"',
+      new_string: 'return "hello"',
+    }, signal);
+    const content = typeof result === 'string' ? result : result.content;
+    expect(content).not.toMatch(/[Tt]raversal|[Bb]locked/);
+  });
+
+  it('allows any path when no workingDir is set (backward compat)', async () => {
+    const tool = createFileEditTool();
+    const result = await tool.execute({
+      file_path: join(tempDir, 'code.ts'),
+      old_string: 'return "world"',
+      new_string: 'return "hello"',
+    }, signal);
+    const content = typeof result === 'string' ? result : result.content;
+    expect(content).not.toMatch(/[Tt]raversal|[Bb]locked/);
+  });
 });

--- a/tests/unit/tools/builtin/file-write.test.ts
+++ b/tests/unit/tools/builtin/file-write.test.ts
@@ -57,4 +57,45 @@ describe('builtin/file-write', () => {
     const content = typeof result === 'string' ? result : result.content;
     expect(content).toContain('3 bytes');
   });
+
+  // --- issue #22: path traversal protection ---
+
+  it('blocks path traversal outside workingDir', async () => {
+    const tool = createFileWriteTool(tempDir);
+    const result = await tool.execute({
+      file_path: join(tempDir, '..', 'escape.txt'),
+      content: 'pwned',
+    }, signal);
+    const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+    expect(parsed.isError).toBe(true);
+    expect(parsed.content).toMatch(/[Tt]raversal|[Bb]locked|outside/);
+  });
+
+  it('blocks absolute path outside workingDir', async () => {
+    const tool = createFileWriteTool(tempDir);
+    const result = await tool.execute({
+      file_path: '/etc/passwd',
+      content: 'pwned',
+    }, signal);
+    const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+    expect(parsed.isError).toBe(true);
+  });
+
+  it('allows write inside workingDir when workingDir is set', async () => {
+    const tool = createFileWriteTool(tempDir);
+    const result = await tool.execute({
+      file_path: join(tempDir, 'safe.txt'),
+      content: 'ok',
+    }, signal);
+    const content = typeof result === 'string' ? result : result.content;
+    expect(content).not.toMatch(/[Tt]raversal|[Bb]locked/);
+  });
+
+  it('allows any path when no workingDir is set (backward compat)', async () => {
+    const tool = createFileWriteTool();
+    const filePath = join(tempDir, 'no-guard.txt');
+    const result = await tool.execute({ file_path: filePath, content: 'ok' }, signal);
+    const content = typeof result === 'string' ? result : result.content;
+    expect(content).toContain('bytes');
+  });
 });


### PR DESCRIPTION
## Issue
Closes #22

## Problema
`createFileWriteTool()` e `createFileEditTool()` aceitavam qualquer `file_path` absoluto sem validação de contenção. Um LLM adversarial podia escrever em `/etc/passwd`, `~/.ssh/authorized_keys` ou sobrescrever binários do sistema.

## Abordagem TDD
- Testes em: `tests/unit/tools/builtin/file-write.test.ts` e `file-edit.test.ts` (4 novos casos cada)
- Falha antes do fix (red): `createFileWriteTool(tempDir)` não aceitava argumento; travessia não era bloqueada
- Implementação mínima em:
  - `src/tools/builtin/path-guard.ts` — função `assertSafePath(filePath, rootDir)` usa `resolve`+`relative` para checar contenção
  - `src/tools/builtin/file-write.ts` — aceita `workingDir?: string`; chama `assertSafePath` antes de qualquer I/O
  - `src/tools/builtin/file-edit.ts` — idem
- Backward-compat: sem `workingDir`, comportamento anterior é preservado
- Suíte completa: 728 testes passam

## Mudanças de regras (justificativa)
Nenhuma. As assinaturas das factories foram estendidas de forma não-breaking (parâmetro opcional).

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (extensão backward-compatible)

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_