### PR TITLE
fix: elimina race condition entre healthCheck e attemptReconnect (closes #24)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -412,25 +412,25 @@ export class MCPAdapter {
   private async healthCheck(name: string): Promise<void> {
     const conn = this.connections.get(name);
     if (!conn) return;
+    // Skip if a reconnect is already in progress — prevents concurrent reconnects.
+    if (conn.status === 'reconnecting') return;
 
     try {
       await conn.client.listTools();
       conn.status = 'connected';
       conn.lastError = undefined;
     } catch (error) {
-      conn.status = 'error';
+      // Set reconnecting BEFORE firing attemptReconnect to close the race window.
+      conn.status = 'reconnecting';
       conn.lastError = error instanceof Error ? error.message : String(error);
-
-      // Attempt reconnection
       void this.attemptReconnect(name);
     }
   }
 
   private async attemptReconnect(name: string): Promise<void> {
     const conn = this.connections.get(name);
-    if (!conn || conn.status === 'reconnecting') return;
-
-    conn.status = 'reconnecting';
+    if (!conn) return;
+    // Status is already 'reconnecting' (set atomically in healthCheck).
     const maxRetries = conn.config.maxRetries ?? 3;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -675,6 +675,84 @@ describe('MCPAdapter', () => {
     });
   });
 
+  describe('healthCheck race condition (issue #24)', () => {
+    it('concurrent healthCheck fires should not start multiple reconnect attempts', async () => {
+      // Regression test: if healthCheck fires while a reconnect is in progress,
+      // only ONE reconnect process should be active (status window elimination).
+      vi.useFakeTimers();
+
+      let reconnectConnectCalls = 0;
+      mockClient.listTools
+        .mockResolvedValueOnce({ tools: [] }) // initial connect
+        .mockRejectedValue(new Error('conn lost')); // all health checks fail
+      mockClient.connect
+        .mockResolvedValueOnce(undefined) // initial connect succeeds
+        .mockImplementation(async () => {
+          reconnectConnectCalls++;
+        });
+
+      await adapter.connect({
+        name: 'hc-race',
+        transport: 'stdio',
+        command: 'node',
+        healthCheckInterval: 100,
+        maxRetries: 1, // one reconnect attempt per reconnect cycle
+      });
+
+      // Advance 200ms: healthCheck fires at 100ms and 200ms.
+      // Both fail → buggy code starts TWO reconnect processes;
+      // fixed code starts ONE (second healthCheck returns early).
+      await vi.advanceTimersByTimeAsync(200);
+
+      // Advance past reconnect delays: first attempt delay=1000ms (starts at 100ms, fires at 1100ms);
+      // a second reconnect (if started at 200ms) fires at 1200ms.
+      await vi.advanceTimersByTimeAsync(2000);
+
+      // Fixed code: exactly 1 reconnect connect call (one process, one attempt).
+      // Buggy code: 2 reconnect connect calls (two concurrent processes, one attempt each).
+      expect(reconnectConnectCalls).toBe(1);
+
+      vi.useRealTimers();
+      await adapter.disconnectAll();
+    });
+
+    it('healthCheck while reconnecting should skip (status stays reconnecting)', async () => {
+      // After the first healthCheck failure, status should go to 'reconnecting'.
+      // A subsequent healthCheck must NOT overwrite it back to 'error' nor spawn a second reconnect.
+      vi.useFakeTimers();
+
+      mockClient.listTools
+        .mockResolvedValueOnce({ tools: [] })
+        .mockRejectedValue(new Error('conn lost'));
+      mockClient.connect
+        .mockResolvedValueOnce(undefined) // initial
+        .mockImplementation(async () => { /* reconnect — completes */ });
+
+      await adapter.connect({
+        name: 'hc-status',
+        transport: 'stdio',
+        command: 'node',
+        healthCheckInterval: 100,
+        maxRetries: 1,
+      });
+
+      // Fire first health check — should transition to 'reconnecting'
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Fire second health check while first reconnect's delay is pending
+      // Fixed code: guard at top of healthCheck skips; status stays 'reconnecting'.
+      // Buggy code: listTools fails → status set to 'error' (briefly) then reconnecting again.
+      await vi.advanceTimersByTimeAsync(100);
+
+      // After the second fire, status must still be 'reconnecting' (not 'error')
+      const status = adapter.getHealth().servers.find(s => s.name === 'hc-status')?.status;
+      expect(status).toBe('reconnecting');
+
+      vi.useRealTimers();
+      await adapter.disconnectAll();
+    });
+  });
+
   describe('namespace collision (issue #2)', () => {
     it('should sanitize __ in serverName to prevent namespace collision', async () => {
       mockClient.listTools.mockResolvedValueOnce({


### PR DESCRIPTION
## Issue
Closes #24

## Problema
`healthCheck()` disparava com `void this.attemptReconnect(name)` depois de definir `conn.status = 'error'`. Se o intervalo disparasse novamente nessa janela (durante o delay de reconexão), o segundo `healthCheck` via `listTools` falhava novamente, sobrescrevia o status para `'error'`, e iniciava um segundo `attemptReconnect` concorrente — causando conexões TCP duplicadas e potencial registro duplo de tools.

## Abordagem TDD
- Testes em: `tests/unit/tools/mcp-adapter.test.ts` (describe `healthCheck race condition (issue #24)`)
- Falha antes do fix (red): `concurrent healthCheck fires...` falhava — 2 reconnect calls em vez de 1
- Implementação mínima em: `src/tools/mcp-adapter.ts`
  - Adiciona `if (conn.status === 'reconnecting') return` no início de `healthCheck`
  - Move atribuição para `'reconnecting'` para antes de `void this.attemptReconnect()`
  - Remove linha duplicada em `attemptReconnect`
- Suíte completa: 722 testes passam

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_