### PR TITLE
fix: lança erro em tool_calls corrompido em SQLiteConversationStore (closes #25)

### DIFF
--- a/src/storage/sqlite-conversation-store.ts
+++ b/src/storage/sqlite-conversation-store.ts
@@ -63,7 +63,13 @@ function rowToMessage(row: ConversationRow): ChatMessage {
 
   let toolCalls: ChatMessage['toolCalls'];
   if (row.tool_calls) {
-    try { toolCalls = JSON.parse(row.tool_calls); } catch { toolCalls = undefined; }
+    try {
+      toolCalls = JSON.parse(row.tool_calls);
+    } catch (e) {
+      throw new Error(
+        `Corrupted tool_calls in conversation row id=${row.id}, thread=${row.thread_id}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
   }
 
   return {

--- a/tests/unit/storage/sqlite-conversation-store.test.ts
+++ b/tests/unit/storage/sqlite-conversation-store.test.ts
@@ -81,15 +81,17 @@ describe('SQLiteConversationStore', () => {
     expect(messages[1]!.toolCallId).toBe('tc1');
   });
 
-  it('should return undefined toolCalls for corrupt tool_calls JSON', () => {
+  // --- issue #25: corrupted tool_calls must not be silently discarded ---
+
+  it('should throw on corrupted tool_calls JSON (not silently discard)', () => {
+    // Simulates a row written by a partial write, migration error, or manual DB edit.
     database.db.prepare(`
       INSERT INTO conversations (thread_id, role, content, tool_calls, tool_call_id, pinned, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run('t-corrupt', 'assistant', '""', 'NOT_VALID_JSON{{{', null, 0, Date.now());
 
-    const messages = store.listThread('t-corrupt');
-    expect(messages).toHaveLength(1);
-    expect(messages[0]!.toolCalls).toBeUndefined();
+    // Must throw with context (row id + thread id) so operators can diagnose the issue.
+    expect(() => store.listThread('t-corrupt')).toThrow(/tool_calls|Corrupted/i);
   });
 
   it('should return empty array for unknown thread', () => {


### PR DESCRIPTION
## Issue
Closes #25

## Problema
O catch block em `rowToMessage` silenciosamente retornava `toolCalls = undefined` quando o JSON em `tool_calls` era inválido. Isso causava: (1) agente reexecutando ferramentas já chamadas, (2) LLM recebendo sequência de mensagens inválida (assistant com tool_use sem tool response correspondente → HTTP 400), (3) diagnóstico impossível em produção por ausência de log.

## Abordagem TDD
- Teste atualizado em: `tests/unit/storage/sqlite-conversation-store.test.ts`
- Falha antes do fix (red): `listThread` retornava silenciosamente mensagem com `toolCalls: undefined`
- Implementação mínima em: `src/storage/sqlite-conversation-store.ts:65-72` — catch lança `Error` com `row.id` e `thread_id` para diagnóstico em produção
- Suíte completa: 720 testes passam

## Mudanças de regras (justificativa)
Nenhuma. Alinhado com o princípio arquitetural "Falhe explicitamente" do CLAUDE.md.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_