### PR TITLE
fix: loga warning em tool_calls corrompido no SQLiteConversationStore (closes #25)

### DIFF
--- a/src/storage/sqlite-conversation-store.ts
+++ b/src/storage/sqlite-conversation-store.ts
@@ -63,7 +63,12 @@ function rowToMessage(row: ConversationRow): ChatMessage {
 
   let toolCalls: ChatMessage['toolCalls'];
   if (row.tool_calls) {
-    try { toolCalls = JSON.parse(row.tool_calls); } catch { toolCalls = undefined; }
+    try {
+      toolCalls = JSON.parse(row.tool_calls);
+    } catch (e) {
+      console.warn(`[SQLiteConversationStore] Invalid tool_calls JSON — row.id=${row.id}, thread=${row.thread_id}`, e);
+      toolCalls = undefined;
+    }
   }
 
   return {

--- a/tests/unit/storage/sqlite-conversation-store.test.ts
+++ b/tests/unit/storage/sqlite-conversation-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteDatabase } from '../../../src/storage/sqlite-database.js';
 import { SQLiteConversationStore } from '../../../src/storage/sqlite-conversation-store.js';
 import type { ChatMessage } from '../../../src/contracts/entities/chat-message.js';
@@ -90,6 +90,22 @@ describe('SQLiteConversationStore', () => {
     const messages = store.listThread('t-corrupt');
     expect(messages).toHaveLength(1);
     expect(messages[0]!.toolCalls).toBeUndefined();
+  });
+
+  it('should warn via console.warn when tool_calls JSON is corrupt (issue #25)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    database.db.prepare(`
+      INSERT INTO conversations (thread_id, role, content, tool_calls, tool_call_id, pinned, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('t-corrupt-warn', 'assistant', '""', 'NOT_VALID_JSON{{{', null, 0, Date.now());
+
+    store.listThread('t-corrupt-warn');
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [firstArg] = warnSpy.mock.calls[0]!;
+    expect(firstArg).toMatch(/SQLiteConversationStore/);
+    expect(firstArg).toMatch(/tool_calls/);
+    warnSpy.mockRestore();
   });
 
   it('should return empty array for unknown thread', () => {


### PR DESCRIPTION
## Issue
Closes #25

## Problema
O bloco `catch` em `rowToMessage` silenciava erros de JSON inválido em `tool_calls`, retornando `undefined` sem nenhum log. Em produção, isso tornava impossível diagnosticar corrupção de banco ou writes parciais.

## Abordagem TDD
- Teste em: `tests/unit/storage/sqlite-conversation-store.test.ts` (`should warn via console.warn when tool_calls JSON is corrupt`)
- Falha antes do fix (red): `warnSpy` nunca chamado — 0 invocações
- Implementação mínima em: `src/storage/sqlite-conversation-store.ts` — `console.warn` com `row.id` e `row.thread_id` no catch
- Suíte completa: 735 testes verdes (1 failure pre-existente em `teams-bot/agent-factory.test.ts` por `dist/` ausente)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_