### PR TITLE
fix: guard em getCompletedResults e getRemainingResults contra result undefined (closes #27)

### DIFF
--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -73,12 +73,9 @@ export class StreamingToolExecutor {
     for (const tool of this.tools) {
       if (tool.status === 'completed') {
         tool.status = 'yielded';
-        yield {
-          id: tool.id,
-          name: tool.name,
-          result: tool.result!,
-          duration: tool.duration!,
-        };
+        if (tool.result !== undefined && tool.duration !== undefined) {
+          yield { id: tool.id, name: tool.name, result: tool.result, duration: tool.duration };
+        }
       } else if (tool.status !== 'yielded') {
         break;
       }
@@ -108,12 +105,9 @@ export class StreamingToolExecutor {
       }
 
       tool.status = 'yielded';
-      yield {
-        id: tool.id,
-        name: tool.name,
-        result: tool.result!,
-        duration: tool.duration!,
-      };
+      if (tool.result !== undefined && tool.duration !== undefined) {
+        yield { id: tool.id, name: tool.name, result: tool.result, duration: tool.duration };
+      }
     }
   }
 

--- a/tests/unit/core/streaming-tool-executor.test.ts
+++ b/tests/unit/core/streaming-tool-executor.test.ts
@@ -310,6 +310,21 @@ describe('StreamingToolExecutor', () => {
     expect(receivedArgs[1]).toEqual({ input: 'hello' });
   });
 
+  it('getCompletedResults should skip tool with undefined result despite completed status (issue #27)', () => {
+    const executor = new ToolExecutor();
+    const streaming = new StreamingToolExecutor(executor);
+
+    // Simulate invariant violation: status='completed' but result/duration not set
+    (streaming as unknown as { tools: unknown[] }).tools.push({
+      id: 'broken', name: 'test', args: '{}', parsedArgs: {},
+      isSafe: false, status: 'completed', result: undefined, duration: undefined, progressEvents: [],
+    });
+
+    const results = [...streaming.getCompletedResults()];
+    // Guard must skip this tool rather than yielding result: undefined
+    expect(results).toHaveLength(0);
+  });
+
   it('getCompletedResults should be non-blocking and yield only finished tools', async () => {
     const executor = new ToolExecutor();
     executor.register(createTool({


### PR DESCRIPTION
## Issue
Closes #27

## Problema
`getCompletedResults()` e `getRemainingResults()` usavam `tool.result!` e `tool.duration!` (non-null assertion) para acessar campos opcionais no `TrackedTool`. Se qualquer path de código definisse `status='completed'` sem preencher `result`/`duration`, o runtime receberia `undefined` onde `AgentToolResult` é esperado.

## Abordagem TDD
- Teste em: `tests/unit/core/streaming-tool-executor.test.ts` (`getCompletedResults should skip tool with undefined result despite completed status`)
- Falha antes do fix (red): `results.length === 1` com `result: undefined` — yield acontecia mesmo sem valor
- Implementação mínima em: `src/core/streaming-tool-executor.ts` — guard `if (tool.result !== undefined && tool.duration !== undefined)` antes de `yield` em ambos os métodos; `tool.status = 'yielded'` é sempre atualizado para evitar loop infinito
- Suíte completa: 735 testes verdes

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_