### PR TITLE
fix: eleva debug→warn em falhas de init de memória e skills no Agent (closes #30)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -111,7 +111,10 @@ export class Agent {
       );
       // Ensure memory directory exists (fire-and-forget)
       void this.fileMemorySystem.ensureDir().catch(err => {
-        this.logger.debug('Failed to create memory dir', { error: String(err) });
+        this.logger.warn('Memory directory initialization failed — persistent memory disabled', {
+          memoryDir: config.memory?.memoryDir,
+          error: String(err),
+        });
       });
     }
 
@@ -137,7 +140,10 @@ export class Agent {
     // Auto-load skills from directory (fire-and-forget)
     if (config.skills?.skillsDir) {
       void this.skillManager.loadFromDirectory(config.skills.skillsDir).catch(err => {
-        this.logger.debug('Failed to load skills dir', { error: String(err) });
+        this.logger.warn('Skills directory loading failed — skills unavailable', {
+          skillsDir: config.skills.skillsDir,
+          error: String(err),
+        });
       });
     }
 

--- a/tests/unit/agent.test.ts
+++ b/tests/unit/agent.test.ts
@@ -133,4 +133,45 @@ describe('Agent', () => {
     expect(typeof filename).toBe('string');
     expect(filename).toMatch(/\.md$/);
   });
+
+  it('should emit console.warn (not debug) when memoryDir initialization fails (issue #30)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // /dev/null/memory is always uncreateable (ENOTDIR) — forces ensureDir() to fail
+    Agent.create({
+      apiKey: 'test-key',
+      logLevel: 'info',  // info threshold: debug is suppressed, warn is emitted
+      memory: { enabled: true, memoryDir: '/dev/null/memory' },
+      knowledge: { enabled: false },
+    });
+
+    // Fire-and-forget — let the promise settle
+    await new Promise(r => setTimeout(r, 100));
+
+    const memoryWarn = warnSpy.mock.calls.find(c => String(c[0]).toLowerCase().includes('memory'));
+    expect(memoryWarn).toBeDefined();
+    warnSpy.mockRestore();
+  });
+
+  it('should emit console.warn (not debug) when skillsDir loading fails (issue #30)', async () => {
+    const { SkillManager } = await import('../../src/skills/skill-manager.js');
+    const loadSpy = vi.spyOn(SkillManager.prototype, 'loadFromDirectory')
+      .mockRejectedValue(new Error('EACCES: permission denied'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    Agent.create({
+      apiKey: 'test-key',
+      logLevel: 'info',
+      memory: { enabled: false },
+      knowledge: { enabled: false },
+      skills: { skillsDir: '/some/restricted/skills' },
+    });
+
+    await new Promise(r => setTimeout(r, 100));
+
+    const skillsWarn = warnSpy.mock.calls.find(c => String(c[0]).toLowerCase().includes('skill'));
+    expect(skillsWarn).toBeDefined();
+    loadSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Issue
Closes #30

## Problema
O `Agent.constructor` usava `logger.debug(...)` nos handlers de falha das promises fire-and-forget de `ensureDir()` e `loadFromDirectory()`. Em produção com `logLevel: 'info'` (padrão), mensagens `debug` são silenciadas — o integrador nunca sabe que a memória ou os skills não foram carregados.

## Abordagem TDD
- Testes em: `tests/unit/agent.test.ts` (2 novos casos)
- Falha antes do fix (red): `console.warn` não chamado; threshold `info` suprime `debug`
- Implementação mínima em: `src/agent.ts`
  - `ensureDir` catch: `debug` → `warn` com mensagem descritiva e `memoryDir` no contexto
  - `loadFromDirectory` catch: `debug` → `warn` com `skillsDir` no contexto
- Nota: `scanSkillFiles` swallows erros internamente (pré-existente); o teste usa `vi.spyOn` em `SkillManager.prototype.loadFromDirectory` para simular rejeição
- Suíte completa: 736 testes verdes

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_