### PR TITLE
fix: replace non-null assertions with explicit guards in StreamingToolExecutor (#27)

### DIFF
--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -72,12 +72,15 @@ export class StreamingToolExecutor {
   *getCompletedResults(): Generator<ToolExecutionResult> {
     for (const tool of this.tools) {
       if (tool.status === 'completed') {
+        if (tool.result === undefined || tool.duration === undefined) {
+          throw new Error(`Tool "${tool.id}" completed but result or duration not set`);
+        }
         tool.status = 'yielded';
         yield {
           id: tool.id,
           name: tool.name,
-          result: tool.result!,
-          duration: tool.duration!,
+          result: tool.result,
+          duration: tool.duration,
         };
       } else if (tool.status !== 'yielded') {
         break;
@@ -107,12 +110,16 @@ export class StreamingToolExecutor {
         await tool.promise;
       }
 
+      if (tool.result === undefined || tool.duration === undefined) {
+        throw new Error(`Tool "${tool.id}" completed but result or duration not set`);
+      }
+
       tool.status = 'yielded';
       yield {
         id: tool.id,
         name: tool.name,
-        result: tool.result!,
-        duration: tool.duration!,
+        result: tool.result,
+        duration: tool.duration,
       };
     }
   }

--- a/tests/unit/core/streaming-tool-executor.test.ts
+++ b/tests/unit/core/streaming-tool-executor.test.ts
@@ -310,6 +310,40 @@ describe('StreamingToolExecutor', () => {
     expect(receivedArgs[1]).toEqual({ input: 'hello' });
   });
 
+  describe('non-null safety on result/duration (issue #27)', () => {
+    function injectBrokenCompletedTool(streaming: StreamingToolExecutor): void {
+      const tools = (streaming as unknown as { tools: Array<Record<string, unknown>> }).tools;
+      tools.push({
+        id: 'broken',
+        name: 'test_tool',
+        args: '{}',
+        parsedArgs: {},
+        isSafe: true,
+        status: 'completed',
+        // result and duration intentionally omitted to simulate invariant violation
+        progressEvents: [],
+      });
+    }
+
+    it('getCompletedResults should throw instead of silently yielding undefined result', () => {
+      const executor = new ToolExecutor();
+      const streaming = new StreamingToolExecutor(executor);
+      injectBrokenCompletedTool(streaming);
+
+      expect(() => [...streaming.getCompletedResults()]).toThrow(/result.*duration|not set/i);
+    });
+
+    it('getRemainingResults should throw instead of silently yielding undefined result', async () => {
+      const executor = new ToolExecutor();
+      const streaming = new StreamingToolExecutor(executor);
+      injectBrokenCompletedTool(streaming);
+
+      await expect(async () => {
+        for await (const _ of streaming.getRemainingResults()) { /* drain */ }
+      }).rejects.toThrow(/result.*duration|not set/i);
+    });
+  });
+
   it('getCompletedResults should be non-blocking and yield only finished tools', async () => {
     const executor = new ToolExecutor();
     executor.register(createTool({


### PR DESCRIPTION
## Summary

- `getCompletedResults()` and `getRemainingResults()` in `StreamingToolExecutor` used `tool.result!` and `tool.duration!` — TypeScript non-null assertions with no runtime protection.
- Replaced both with explicit guards that throw a descriptive `Error` if either field is `undefined` when a tool's status is `'completed'`, making the invariant violation visible rather than silently propagating `undefined` downstream.

## Changes

- `src/core/streaming-tool-executor.ts`: removed `!` assertions; added `if (result === undefined || duration === undefined) throw` before each `yield`
- `tests/unit/core/streaming-tool-executor.test.ts`: two new tests verify both generators throw when the invariant is violated (injected via private-field cast)

## Test plan

- [ ] `pnpm test tests/unit/core/streaming-tool-executor.test.ts` — all 11 tests pass
- [ ] `pnpm test` — full suite (722 tests) passes; pre-existing `agent-factory.test.ts` failure is unrelated (missing build artefact)

closes #27

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_