### PR TITLE
feat: timeoutMs configurável no LLMClientConfig (closes #29)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -13,6 +13,7 @@ export interface LLMClientConfig {
   apiKey: string;
   model: string;
   baseUrl?: string;
+  timeoutMs?: number;
 }
 
 function isRetryableStatus(status: number): boolean {
@@ -46,11 +47,13 @@ export class LLMClient {
   private readonly apiKey: string;
   private readonly model: string;
   private readonly baseUrl: string;
+  private readonly timeoutMs: number;
 
   constructor(config: LLMClientConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model;
     this.baseUrl = (config.baseUrl ?? 'https://openrouter.ai/api/v1').replace(/\/$/, '');
+    this.timeoutMs = config.timeoutMs ?? LLMClient.DEFAULT_TIMEOUT_MS;
   }
 
   async *streamChat(params: StreamChatParams): AsyncIterableIterator<StreamChunk> {
@@ -174,7 +177,7 @@ export class LLMClient {
 
   private async fetchAPI(path: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Response> {
     // Always apply a default timeout; compose with the caller-provided signal if any.
-    const signals: AbortSignal[] = [AbortSignal.timeout(LLMClient.DEFAULT_TIMEOUT_MS)];
+    const signals: AbortSignal[] = [AbortSignal.timeout(this.timeoutMs)];
     if (signal) signals.push(signal);
     const effectiveSignal = AbortSignal.any(signals);
 

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -277,6 +277,35 @@ describe('LLMClient', () => {
       expect(init.signal).toBeInstanceOf(AbortSignal);
     });
 
+    it('uses timeoutMs from LLMClientConfig instead of hardcoded default (issue #29)', async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const customClient = new LLMClient({
+        apiKey: 'test-key', model: 'test/model', baseUrl: 'https://api.test.com/v1',
+        timeoutMs: 30_000,
+      } as any);
+      mockFetch(new Response(JSON.stringify({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      }), { status: 200 }));
+
+      await customClient.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+    });
+
+    it('uses default 120000ms timeout when timeoutMs is not specified (issue #29)', async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      mockFetch(new Response(JSON.stringify({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      }), { status: 200 }));
+
+      await client.chat({ messages: [{ role: 'user', content: 'Hi' }] });
+
+      expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+    });
+
     it('flushes UTF-8 decoder at end of stream so no trailing bytes are dropped', async () => {
       // Build a response whose last chunk is the continuation of a multibyte char.
       // The emoji '😀' is 4 bytes in UTF-8: 0xF0 0x9F 0x98 0x80


### PR DESCRIPTION
## Issue
Closes #29

## Problema
`DEFAULT_TIMEOUT_MS = 120_000` era `private static readonly` e não podia ser sobrescrito via config. Integradores com modelos de raciocínio extendido (DeepSeek-R1, o1, claude-thinking) ou alta latência de rede recebiam `AbortError` em chamadas legítimas sem forma de ajustar o timeout.

## Abordagem TDD
- Testes em: `tests/unit/llm/llm-client.test.ts` (2 novos casos)
- Falha antes do fix (red): `AbortSignal.timeout` chamado com `120_000` mesmo quando `timeoutMs: 30_000` passado na config
- Implementação mínima em: `src/llm/llm-client.ts`
  - `LLMClientConfig`: adiciona campo opcional `timeoutMs?: number`
  - `LLMClient`: nova propriedade `private readonly timeoutMs` inicializada com `config.timeoutMs ?? DEFAULT_TIMEOUT_MS`
  - `fetchAPI`: substitui `LLMClient.DEFAULT_TIMEOUT_MS` por `this.timeoutMs`
- Backward-compat: sem `timeoutMs`, comportamento anterior (120s) é preservado
- Suíte completa: 736 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. `LLMClientConfig` é uma interface pública — extensão não-breaking com campo opcional.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_