### PR TITLE
fix: validação Zod em listResources, readResource e getPrompt no MCPAdapter (closes #28)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -5,6 +5,29 @@ import type { MCPConnectionConfig } from '../config/config.js';
 import type { ToolExecutor } from './tool-executor.js';
 import { jsonSchemaToZod } from './json-schema-to-zod.js';
 
+const MCPResourceListSchema = z.object({
+  resources: z.array(z.object({
+    uri: z.string(),
+    name: z.string(),
+    mimeType: z.string().optional(),
+    description: z.string().optional(),
+  })),
+});
+
+const MCPResourceReadSchema = z.object({
+  contents: z.array(z.object({
+    text: z.string().optional(),
+    uri: z.string(),
+  })),
+});
+
+const MCPGetPromptSchema = z.object({
+  messages: z.array(z.object({
+    role: z.string(),
+    content: z.union([z.string(), z.object({ type: z.string(), text: z.string().optional() }).passthrough()]),
+  })),
+});
+
 /** Shape of the content array returned from MCP server tool calls. */
 const MCPToolContentSchema = z.array(
   z.object({
@@ -224,11 +247,13 @@ export class MCPAdapter {
     if (!conn || conn.status !== 'connected') return [];
 
     try {
-      const result = await (conn.client as unknown as {
-        listResources?: () => Promise<{ resources: Array<{ uri: string; name: string; mimeType?: string; description?: string }> }>;
+      const rawResult = await (conn.client as unknown as {
+        listResources?: () => Promise<unknown>;
       }).listResources?.();
-      if (!result) return [];
-      return result.resources.map(r => ({ ...r, serverName }));
+      if (!rawResult) return [];
+      const parsed = MCPResourceListSchema.safeParse(rawResult);
+      if (!parsed.success) return [];
+      return parsed.data.resources.map(r => ({ ...r, serverName }));
     } catch {
       return [];
     }
@@ -241,12 +266,15 @@ export class MCPAdapter {
       throw new Error(`MCP server "${serverName}" not connected`);
     }
 
-    const result = await (conn.client as unknown as {
-      readResource?: (params: { uri: string }) => Promise<{ contents: Array<{ text?: string; uri: string }> }>;
+    const rawResult = await (conn.client as unknown as {
+      readResource?: (params: { uri: string }) => Promise<unknown>;
     }).readResource?.({ uri });
-    if (!result) throw new Error('Server does not support resources');
+    if (!rawResult) throw new Error('Server does not support resources');
 
-    return result.contents.map(c => c.text ?? `[Binary: ${c.uri}]`).join('\n');
+    const parsed = MCPResourceReadSchema.safeParse(rawResult);
+    if (!parsed.success) throw new Error(`MCP server returned invalid resource shape: ${parsed.error.message}`);
+
+    return parsed.data.contents.map(c => c.text ?? `[Binary: ${c.uri}]`).join('\n');
   }
 
   /** Fetch and return a prompt from a server (for skill getPrompt). */
@@ -258,22 +286,22 @@ export class MCPAdapter {
 
     const parsedArgs: Record<string, string> = {};
     if (args) {
-      // Simple key=value parsing from args string
       for (const part of args.split(/\s+/)) {
         const [k, ...v] = part.split('=');
         if (k && v.length > 0) parsedArgs[k] = v.join('=');
       }
     }
 
-    const result = await (conn.client as unknown as {
-      getPrompt?: (params: { name: string; arguments?: Record<string, string> }) => Promise<{
-        messages: Array<{ role: string; content: { type: string; text?: string } | string }>;
-      }>;
+    const rawResult = await (conn.client as unknown as {
+      getPrompt?: (params: { name: string; arguments?: Record<string, string> }) => Promise<unknown>;
     }).getPrompt?.({ name: promptName, arguments: parsedArgs });
 
-    if (!result) throw new Error('Server does not support prompts');
+    if (!rawResult) throw new Error('Server does not support prompts');
 
-    return result.messages.map(m => {
+    const parsed = MCPGetPromptSchema.safeParse(rawResult);
+    if (!parsed.success) throw new Error(`MCP server returned invalid prompt shape: ${parsed.error.message}`);
+
+    return parsed.data.messages.map(m => {
       const content = typeof m.content === 'string' ? m.content : m.content.text ?? '';
       return content;
     }).join('\n');

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -675,6 +675,46 @@ describe('MCPAdapter', () => {
     });
   });
 
+  describe('Zod validation in readResource / getPrompt / listResources (issue #28)', () => {
+    it('readResource should throw clear error when server returns invalid shape', async () => {
+      (mockClient as Record<string, unknown>).readResource = vi.fn().mockResolvedValue({
+        notContents: 'unexpected',  // missing required `contents` array
+      });
+
+      await adapter.connect({ name: 'bad-read', transport: 'stdio', command: 'node' });
+
+      await expect(adapter.readResource('bad-read', 'file:///x.txt'))
+        .rejects.toThrow(/invalid.*shape|invalid resource/i);
+
+      delete (mockClient as Record<string, unknown>).readResource;
+    });
+
+    it('getPrompt should throw clear error when server returns invalid shape', async () => {
+      (mockClient as Record<string, unknown>).getPrompt = vi.fn().mockResolvedValue({
+        notMessages: 'unexpected',  // missing required `messages` array
+      });
+
+      await adapter.connect({ name: 'bad-prompt', transport: 'stdio', command: 'node' });
+
+      await expect(adapter.getPrompt('bad-prompt', 'p'))
+        .rejects.toThrow(/invalid.*shape|invalid prompt/i);
+
+      delete (mockClient as Record<string, unknown>).getPrompt;
+    });
+
+    it('listResources should return empty when server returns invalid shape', async () => {
+      (mockClient as Record<string, unknown>).listResources = vi.fn().mockResolvedValue({
+        notResources: 'unexpected',  // missing required `resources` array
+      });
+
+      await adapter.connect({ name: 'bad-list', transport: 'stdio', command: 'node' });
+      const result = await adapter.listResources('bad-list');
+      expect(result).toEqual([]);  // graceful fallback for list operation
+
+      delete (mockClient as Record<string, unknown>).listResources;
+    });
+  });
+
   describe('namespace collision (issue #2)', () => {
     it('should sanitize __ in serverName to prevent namespace collision', async () => {
       mockClient.listTools.mockResolvedValueOnce({


### PR DESCRIPTION
## Issue
Closes #28

## Problema
`listResources`, `readResource` e `getPrompt` acessavam propriedades de respostas MCP diretamente via `as unknown as { ... }` sem validação. Um servidor adversarial ou mal-implementado que retornasse shape inesperado causaria `TypeError: Cannot read properties of undefined` opaco — difícil de diagnosticar e potencialmente explorável.

## Abordagem TDD
- Testes em: `tests/unit/tools/mcp-adapter.test.ts` (describe `Zod validation in readResource / getPrompt / listResources (issue #28)`)
- Falha antes do fix (red):
  - `readResource` com `{ notContents: '...' }` → `TypeError: ...undefined...map` (não matchava `/invalid.*shape/i`)
  - `getPrompt` com `{ notMessages: '...' }` → idem
- Implementação mínima em: `src/tools/mcp-adapter.ts`
  - Adicionados schemas: `MCPResourceListSchema`, `MCPResourceReadSchema`, `MCPGetPromptSchema`
  - `listResources`: `safeParse` → retorna `[]` se inválido (degradação graciosa para listagem)
  - `readResource`: `safeParse` → lança `Error: MCP server returned invalid resource shape: ...`
  - `getPrompt`: `safeParse` → lança `Error: MCP server returned invalid prompt shape: ...`
- Suíte completa: 737 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. Espelha o padrão já adotado em `MCPToolContentSchema.safeParse` para tool calls.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_