### PR TITLE
fix: Zod validation for MCPAdapter listResources/readResource/getPrompt responses (#28)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -5,6 +5,35 @@ import type { MCPConnectionConfig } from '../config/config.js';
 import type { ToolExecutor } from './tool-executor.js';
 import { jsonSchemaToZod } from './json-schema-to-zod.js';
 
+/** Validated shape of listResources server response. */
+const ListResourcesResultSchema = z.object({
+  resources: z.array(z.object({
+    uri: z.string(),
+    name: z.string(),
+    mimeType: z.string().optional(),
+    description: z.string().optional(),
+  }).passthrough()),
+});
+
+/** Validated shape of readResource server response. */
+const ReadResourceResultSchema = z.object({
+  contents: z.array(z.object({
+    text: z.string().optional(),
+    uri: z.string(),
+  }).passthrough()),
+});
+
+/** Validated shape of getPrompt server response. */
+const GetPromptResultSchema = z.object({
+  messages: z.array(z.object({
+    role: z.string(),
+    content: z.union([
+      z.string(),
+      z.object({ type: z.string(), text: z.string().optional() }).passthrough(),
+    ]),
+  })),
+});
+
 /** Shape of the content array returned from MCP server tool calls. */
 const MCPToolContentSchema = z.array(
   z.object({
@@ -224,11 +253,12 @@ export class MCPAdapter {
     if (!conn || conn.status !== 'connected') return [];
 
     try {
-      const result = await (conn.client as unknown as {
-        listResources?: () => Promise<{ resources: Array<{ uri: string; name: string; mimeType?: string; description?: string }> }>;
+      const raw = await (conn.client as unknown as {
+        listResources?: () => Promise<unknown>;
       }).listResources?.();
-      if (!result) return [];
-      return result.resources.map(r => ({ ...r, serverName }));
+      if (!raw) return [];
+      const parsed = ListResourcesResultSchema.parse(raw);
+      return parsed.resources.map(r => ({ ...r, serverName }));
     } catch {
       return [];
     }
@@ -241,12 +271,13 @@ export class MCPAdapter {
       throw new Error(`MCP server "${serverName}" not connected`);
     }
 
-    const result = await (conn.client as unknown as {
-      readResource?: (params: { uri: string }) => Promise<{ contents: Array<{ text?: string; uri: string }> }>;
+    const raw = await (conn.client as unknown as {
+      readResource?: (params: { uri: string }) => Promise<unknown>;
     }).readResource?.({ uri });
-    if (!result) throw new Error('Server does not support resources');
+    if (!raw) throw new Error('Server does not support resources');
 
-    return result.contents.map(c => c.text ?? `[Binary: ${c.uri}]`).join('\n');
+    const parsed = ReadResourceResultSchema.parse(raw);
+    return parsed.contents.map(c => c.text ?? `[Binary: ${c.uri}]`).join('\n');
   }
 
   /** Fetch and return a prompt from a server (for skill getPrompt). */
@@ -265,15 +296,14 @@ export class MCPAdapter {
       }
     }
 
-    const result = await (conn.client as unknown as {
-      getPrompt?: (params: { name: string; arguments?: Record<string, string> }) => Promise<{
-        messages: Array<{ role: string; content: { type: string; text?: string } | string }>;
-      }>;
+    const raw = await (conn.client as unknown as {
+      getPrompt?: (params: { name: string; arguments?: Record<string, string> }) => Promise<unknown>;
     }).getPrompt?.({ name: promptName, arguments: parsedArgs });
 
-    if (!result) throw new Error('Server does not support prompts');
+    if (!raw) throw new Error('Server does not support prompts');
 
-    return result.messages.map(m => {
+    const parsed = GetPromptResultSchema.parse(raw);
+    return parsed.messages.map(m => {
       const content = typeof m.content === 'string' ? m.content : m.content.text ?? '';
       return content;
     }).join('\n');

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ZodError } from 'zod';
 import { MCPAdapter, type MCPHealthStatus } from '../../../src/tools/mcp-adapter.js';
 import type { ToolExecutor } from '../../../src/tools/tool-executor.js';
 
@@ -615,6 +616,51 @@ describe('MCPAdapter', () => {
       await adapter.connect({ name: 'notext', transport: 'stdio', command: 'node' });
       const result = await adapter.getPrompt('notext', 'p');
       expect(result).toBe('');
+
+      delete (mockClient as Record<string, unknown>).getPrompt;
+    });
+  });
+
+  describe('Zod validation of server responses (issue #28)', () => {
+    it('listResources should return empty when resource is missing required uri field', async () => {
+      (mockClient as Record<string, unknown>).listResources = vi.fn().mockResolvedValue({
+        resources: [{ name: 'no-uri-here' }], // uri is required but missing
+      });
+
+      await adapter.connect({ name: 'zod-res', transport: 'stdio', command: 'node' });
+      const result = await adapter.listResources('zod-res');
+
+      // Without Zod: returns [{ name: 'no-uri-here', uri: undefined, serverName: 'zod-res' }]
+      // With Zod: parse fails → catch returns []
+      expect(result).toHaveLength(0);
+
+      delete (mockClient as Record<string, unknown>).listResources;
+    });
+
+    it('readResource should throw ZodError when contents is not an array', async () => {
+      (mockClient as Record<string, unknown>).readResource = vi.fn().mockResolvedValue({
+        contents: 'not-an-array',
+      });
+
+      await adapter.connect({ name: 'zod-read', transport: 'stdio', command: 'node' });
+
+      // Without Zod: throws TypeError ('not-an-array'.map is not a function)
+      // With Zod: throws ZodError with descriptive validation message
+      await expect(adapter.readResource('zod-read', 'file:///x')).rejects.toBeInstanceOf(ZodError);
+
+      delete (mockClient as Record<string, unknown>).readResource;
+    });
+
+    it('getPrompt should throw ZodError when messages is not an array', async () => {
+      (mockClient as Record<string, unknown>).getPrompt = vi.fn().mockResolvedValue({
+        messages: 'not-an-array',
+      });
+
+      await adapter.connect({ name: 'zod-prompt', transport: 'stdio', command: 'node' });
+
+      // Without Zod: throws TypeError ('not-an-array'.map is not a function)
+      // With Zod: throws ZodError with descriptive validation message
+      await expect(adapter.getPrompt('zod-prompt', 'p')).rejects.toBeInstanceOf(ZodError);
 
       delete (mockClient as Record<string, unknown>).getPrompt;
     });


### PR DESCRIPTION
## Summary

- `listResources`, `readResource`, and `getPrompt` in `MCPAdapter` used `as unknown as { ... }` type casts to call MCP client methods, then accessed the returned data without any validation. A malformed or adversarial MCP server could return wrong types, causing silent data corruption (`listResources`) or confusing TypeErrors (`readResource`, `getPrompt`).
- Added three Zod schemas (`ListResourcesResultSchema`, `ReadResourceResultSchema`, `GetPromptResultSchema`) and applied `.parse()` to each server response before mapping it.
- `listResources` already catches all errors and returns `[]`; Zod failures fold into that same catch block. `readResource` and `getPrompt` now throw a `ZodError` with a clear validation message instead of an opaque `TypeError`.

## Changes

- `src/tools/mcp-adapter.ts`: three new Zod schemas; three methods updated to accept `Promise<unknown>` returns and call `.parse()` before using the data
- `tests/unit/tools/mcp-adapter.test.ts`: three RED→GREEN tests in a `Zod validation of server responses (issue #28)` block

## Test plan

- [ ] `pnpm test tests/unit/tools/mcp-adapter.test.ts` — all 56 tests pass
- [ ] `pnpm test` — 723 tests pass; pre-existing `agent-factory.test.ts` failure unrelated

closes #28

https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAzqk4AJDh1U3aA3gSjHTM)_