### PR TITLE
feat: workingDir (cwd) e allowedCommands no createBashTool (closes #23)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -34,7 +34,16 @@ const BashParams = z.object({
     .describe('Timeout in milliseconds. Default: 120000 (2 minutes). Max: 300000 (5 minutes).'),
 });
 
-export function createBashTool(): AgentTool {
+export interface BashToolOptions {
+  /** Restrict the subprocess working directory. Commands run relative to this path. */
+  workingDir?: string;
+  /** If set, only commands whose first token matches a prefix in this list are allowed. */
+  allowedCommands?: string[];
+}
+
+export function createBashTool(options: BashToolOptions = {}): AgentTool {
+  const { workingDir, allowedCommands } = options;
+
   return {
     name: 'Bash',
     description: 'Execute a shell command and return stdout/stderr.',
@@ -44,6 +53,18 @@ export function createBashTool(): AgentTool {
 
     async execute(rawArgs: unknown, signal: AbortSignal) {
       const { command, timeout } = BashParams.parse(rawArgs);
+
+      if (allowedCommands && allowedCommands.length > 0) {
+        const firstToken = command.trimStart().split(/\s+/)[0] ?? '';
+        const allowed = allowedCommands.some(prefix => firstToken === prefix || firstToken.startsWith(prefix + ' '));
+        if (!allowed) {
+          return {
+            content: `Command not allowed by allowedCommands policy. Allowed prefixes: ${allowedCommands.join(', ')}`,
+            isError: true,
+          };
+        }
+      }
+
       const effectiveTimeout = timeout ?? DEFAULT_TIMEOUT;
 
       return new Promise<string | { content: string; isError?: boolean }>((resolve) => {
@@ -51,6 +72,7 @@ export function createBashTool(): AgentTool {
           timeout: effectiveTimeout,
           maxBuffer: MAX_OUTPUT,
           shell: process.env.SHELL || '/bin/sh',
+          ...(workingDir ? { cwd: workingDir } : {}),
           // Detach on POSIX so the child gets its own process group —
           // lets us kill the whole tree (including backgrounded grandchildren).
           ...(process.platform !== 'win32' ? { detached: true } : {}),

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -46,6 +46,41 @@ describe('builtin/bash', () => {
     expect(content).toContain('line2');
   });
 
+  describe('sandboxing: workingDir + allowedCommands (issue #23)', () => {
+    it('should restrict cwd to workingDir when set', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tool = createBashTool({ workingDir: '/tmp' } as any);
+      const result = await tool.execute({ command: 'pwd' }, signal);
+      const content = (typeof result === 'string' ? result : result.content).trim();
+      // Must run inside /tmp, not the process cwd
+      expect(content).toBe('/tmp');
+    });
+
+    it('should allow commands matching allowedCommands prefixes', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tool = createBashTool({ allowedCommands: ['echo', 'pwd'] } as any);
+      const result = await tool.execute({ command: 'echo allowed' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('allowed');
+    });
+
+    it('should block commands not in allowedCommands', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tool = createBashTool({ allowedCommands: ['echo'] } as any);
+      const result = await tool.execute({ command: 'ls /' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/not allowed|allowedCommands/i);
+    });
+
+    it('should allow all commands when allowedCommands is not set', async () => {
+      const tool = createBashTool();  // no restrictions
+      const result = await tool.execute({ command: 'echo unrestricted' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('unrestricted');
+    });
+  });
+
   describe('timeout parameter bounds (issue #9)', () => {
     it('should reject timeout=0 (would disable exec timeout)', async () => {
       const tool = createBashTool();


### PR DESCRIPTION
## Issue
Closes #23

## Problema
O `createBashTool()` executava qualquer comando shell sem restrições de diretório ou lista de comandos permitidos. Via prompt injection, um LLM adversarial podia executar `rm -rf /`, exfiltrar dados ou abrir shells reversos com os privilégios do processo Node.

## Abordagem TDD
Implementa as **opções 4 + 2** confirmadas pelo owner no comentário da issue.

- Testes em: `tests/unit/tools/builtin/bash.test.ts` (describe `sandboxing: workingDir + allowedCommands`)
- Falha antes do fix (red):
  - `createBashTool({ workingDir: '/tmp' })` ignorava o parâmetro — `pwd` retornava cwd errado
  - `createBashTool({ allowedCommands: ['echo'] })` não bloqueava `ls /`
- Implementação mínima em: `src/tools/builtin/bash.ts`
  - Nova interface `BashToolOptions`: `workingDir?: string`, `allowedCommands?: string[]`
  - `workingDir`: passado como `cwd` ao `exec()` — restringe diretório de trabalho (opção 4)
  - `allowedCommands`: valida primeiro token do comando antes de executar; retorna `isError: true` com mensagem de bloqueio (opção 2)
  - Backward-compat: `createBashTool()` sem args mantém comportamento original
- Suíte completa: 738 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. Assinatura estendida com parâmetro opcional — não-breaking.

## Limitações conhecidas
- `workingDir` muda o `cwd` mas não impede `cd /etc && cat passwd`
- `allowedCommands` valida o primeiro token; `sh -c "rm -rf /"` passaria com `sh` na lista
- Para isolamento completo: sandbox de SO (firejail/nsjail) está fora do escopo de biblioteca in-process

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (extensão backward-compatible)

https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaSKmwo3WESxcJfJTLL8Ma)_