### PR TITLE
fix: bloqueia metacaracteres shell em allowedCommands (closes #46)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -55,8 +55,17 @@ export function createBashTool(options: BashToolOptions = {}): AgentTool {
       const { command, timeout } = BashParams.parse(rawArgs);
 
       if (allowedCommands && allowedCommands.length > 0) {
+        // Reject shell metacharacters that allow command chaining/injection even when the
+        // first token is in the allow-list (e.g. "ls; rm -rf /", "echo hi | cat").
+        const DANGEROUS_METACHAR = /[;&|`$<>()\n\\]/;
+        if (DANGEROUS_METACHAR.test(command)) {
+          return {
+            content: 'Command contains forbidden shell metacharacters',
+            isError: true,
+          };
+        }
         const firstToken = command.trimStart().split(/\s+/)[0] ?? '';
-        const allowed = allowedCommands.some(prefix => firstToken === prefix || firstToken.startsWith(prefix + ' '));
+        const allowed = allowedCommands.some(prefix => firstToken === prefix);
         if (!allowed) {
           return {
             content: `Command not allowed by allowedCommands policy. Allowed prefixes: ${allowedCommands.join(', ')}`,

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -81,6 +81,57 @@ describe('builtin/bash', () => {
     });
   });
 
+  describe('metacharacter injection via allowedCommands (issue #46)', () => {
+    // allowedCommands: ['echo'] only — 'ls' is NOT in the list
+    const tool = createBashTool({ allowedCommands: ['echo'] });
+
+    it('blocks semicolon chaining: echo hi; ls /', async () => {
+      // 'echo' is allowed but ';' lets 'ls' bypass the allowedCommands check
+      const result = await tool.execute({ command: 'echo hi; ls /' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden|not allowed/i);
+    });
+
+    it('blocks && chaining: echo hi && ls /', async () => {
+      const result = await tool.execute({ command: 'echo hi && ls /' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks pipe: echo hi | cat', async () => {
+      const result = await tool.execute({ command: 'echo hi | cat' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks backtick substitution: echo `whoami`', async () => {
+      const result = await tool.execute({ command: 'echo `whoami`' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks $() substitution: echo $(whoami)', async () => {
+      const result = await tool.execute({ command: 'echo $(whoami)' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('still allows safe allowed commands without metacharacters', async () => {
+      const result = await tool.execute({ command: 'echo hello' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('hello');
+    });
+
+    it('does NOT block metacharacters when allowedCommands is not set', async () => {
+      const unrestricted = createBashTool();
+      const result = await unrestricted.execute({ command: 'echo "line1" && echo "line2"' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('line1');
+      expect(content).toContain('line2');
+    });
+  });
+
   describe('timeout parameter bounds (issue #9)', () => {
     it('should reject timeout=0 (would disable exec timeout)', async () => {
       const tool = createBashTool();


### PR DESCRIPTION
## Issue
Closes #46

## Problema
`allowedCommands` verificava apenas o primeiro token do comando, permitindo encadeamento via `;`, `&&`, `|`, `` ` `` e `$()`. Um agente poderia executar `echo hi; rm -rf /important` mesmo com `allowedCommands: ['echo']`.

Também havia código morto: `firstToken.startsWith(prefix + ' ')` — após `split(/\s+/)`, o `firstToken` nunca contém espaço.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/bash.test.ts` (suite `metacharacter injection via allowedCommands`)
- Falha antes do fix (red): 5 testes falhando — `;`, `&&`, `|`, backtick e `$()` bypassavam a lista
- Implementação mínima em: `src/tools/builtin/bash.ts` — rejeita `/[;&|`$<>()\n\\]/` antes de checar primeiro token; remove código morto
- Suíte completa: verde (4 falhas pré-existentes de issues #24/#27/#28 não relacionadas)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_