### PR TITLE
fix: assertSafePath resolve symlinks via realpathSync (closes #47)

### DIFF
--- a/src/tools/builtin/path-guard.ts
+++ b/src/tools/builtin/path-guard.ts
@@ -1,13 +1,31 @@
-import { resolve, relative, isAbsolute } from 'node:path';
+import { resolve, relative, isAbsolute, dirname, basename } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+
+/**
+ * Resolve symlinks starting from the deepest existing path component.
+ * Handles paths that don't yet exist by walking up to the nearest existing ancestor.
+ */
+function resolveReal(p: string): string {
+  if (existsSync(p)) return realpathSync(p);
+  const parent = dirname(p);
+  if (parent === p) return p; // filesystem root
+  return resolve(resolveReal(parent), basename(p));
+}
 
 /**
  * Asserts that filePath is contained within rootDir.
- * Throws if the resolved path escapes the root (path traversal).
+ * Throws if the resolved path (including symlinks) escapes the root.
  */
 export function assertSafePath(filePath: string, rootDir: string): void {
   const abs = resolve(filePath);
   const rel = relative(rootDir, abs);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(`Path traversal blocked: "${filePath}" is outside working directory "${rootDir}"`);
+  }
+  // Resolve symlinks to catch traversal via symlinks inside workDir
+  const real = resolveReal(abs);
+  const realRel = relative(rootDir, real);
+  if (realRel.startsWith('..') || isAbsolute(realRel)) {
+    throw new Error(`Path traversal via symlink blocked: "${filePath}" resolves outside working directory "${rootDir}"`);
   }
 }

--- a/tests/unit/tools/builtin/path-guard.test.ts
+++ b/tests/unit/tools/builtin/path-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertSafePath } from '../../../../src/tools/builtin/path-guard.js';
+
+describe('assertSafePath', () => {
+  let workDir: string;
+  let outsideDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'path-guard-work-'));
+    outsideDir = await mkdtemp(join(tmpdir(), 'path-guard-outside-'));
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it('allows a regular file inside workDir', async () => {
+    const file = join(workDir, 'safe.txt');
+    await writeFile(file, 'ok');
+    expect(() => assertSafePath(file, workDir)).not.toThrow();
+  });
+
+  it('blocks a path that escapes workDir via ..', () => {
+    const escape = join(workDir, '..', 'etc', 'passwd');
+    expect(() => assertSafePath(escape, workDir)).toThrow(/traversal|outside/i);
+  });
+
+  it('blocks an absolute path outside workDir', () => {
+    expect(() => assertSafePath('/etc/passwd', workDir)).toThrow(/traversal|outside/i);
+  });
+
+  // --- issue #47: symlink traversal ---
+
+  it('blocks a symlink inside workDir that points to a file outside (issue #47)', async () => {
+    const targetFile = join(outsideDir, 'secret.txt');
+    await writeFile(targetFile, 'sensitive');
+    const link = join(workDir, 'safe-link.txt');
+    await symlink(targetFile, link);
+    // path.resolve('workDir/safe-link.txt') → 'workDir/safe-link.txt' (inside root)
+    // BUT realpathSync follows the symlink → outsideDir/secret.txt (outside root)
+    expect(() => assertSafePath(link, workDir)).toThrow(/symlink|traversal|outside/i);
+  });
+
+  it('blocks a symlink inside workDir that points to a directory outside (issue #47)', async () => {
+    const link = join(workDir, 'outside-dir-link');
+    await symlink(outsideDir, link);
+    expect(() => assertSafePath(join(link, 'anything'), workDir)).toThrow(/symlink|traversal|outside/i);
+  });
+});


### PR DESCRIPTION
## Issue
Closes #47

## Problema
`assertSafePath` usava `path.resolve()` que apenas normaliza strings mas não segue symlinks. Um symlink `workDir/safe-link → /etc/passwd` passava na verificação pois `resolve('workDir/safe-link')` retorna `workDir/safe-link` (dentro do rootDir), mas o acesso real segue o symlink para fora.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/path-guard.test.ts` (novos testes de symlink)
- Falha antes do fix (red): symlink file e symlink directory não eram bloqueados
- Implementação mínima em: `src/tools/builtin/path-guard.ts` — `resolveReal()` recursiva que aplica `realpathSync` no ancestral mais próximo existente, depois revalida dentro do rootDir
- Suíte completa: verde (4 falhas pré-existentes de issues #24/#27/#28 não relacionadas)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_