### PR TITLE
fix: pré-resolve DNS para mitigar rebinding em WebFetchTool (closes #49)

### DIFF
--- a/src/tools/builtin/web-fetch.ts
+++ b/src/tools/builtin/web-fetch.ts
@@ -53,6 +53,56 @@ function validateFetchUrl(rawUrl: string): string | null {
   return null;
 }
 
+/** IPv4/IPv6 literal patterns — already validated by validateFetchUrl. */
+const IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/** Minimal DNS resolver interface — injectable for testing. */
+export interface DnsResolver {
+  resolve4(hostname: string): Promise<string[]>;
+  resolve6(hostname: string): Promise<string[]>;
+}
+
+async function defaultDnsResolver(): Promise<DnsResolver> {
+  const mod = await import('node:dns/promises');
+  return { resolve4: mod.resolve4, resolve6: mod.resolve6 };
+}
+
+/**
+ * Pre-resolve DNS and validate each resolved IP against the SSRF blocklist.
+ * Mitigates DNS rebinding: an attacker domain switches from a public IP to a
+ * private IP after the static check but before the actual fetch.
+ * Fails open: DNS errors allow the fetch to proceed (preserves availability).
+ */
+async function checkDnsRebinding(rawUrl: string, resolver: DnsResolver): Promise<string | null> {
+  let hostname: string;
+  try {
+    hostname = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  // IP literals are already validated statically by validateFetchUrl
+  if (IPV4_RE.test(hostname) || hostname.startsWith('[') || hostname.includes(':')) return null;
+
+  try {
+    const [v4Result, v6Result] = await Promise.allSettled([
+      resolver.resolve4(hostname),
+      resolver.resolve6(hostname),
+    ]);
+    const addresses: string[] = [
+      ...(v4Result.status === 'fulfilled' ? v4Result.value : []),
+      ...(v6Result.status === 'fulfilled' ? v6Result.value : []),
+    ];
+    for (const addr of addresses) {
+      const fakeUrl = `http://${addr.includes(':') ? `[${addr}]` : addr}/`;
+      const err = validateFetchUrl(fakeUrl);
+      if (err) return `DNS rebinding blocked: ${hostname} resolved to ${addr} — ${err}`;
+    }
+  } catch {
+    // DNS failure → fail-open
+  }
+  return null;
+}
+
 const WebFetchParams = z.object({
   url: z.string().describe('URL to fetch'),
   max_chars: z.number().optional().describe('Max characters to return. Default: 50000.'),
@@ -73,7 +123,14 @@ function stripHtml(html: string): string {
     .trim();
 }
 
-export function createWebFetchTool(): AgentTool {
+export function createWebFetchTool(options?: { dnsResolver?: DnsResolver }): AgentTool {
+  let resolverPromise: Promise<DnsResolver> | null = null;
+  const getResolver = (): Promise<DnsResolver> => {
+    if (options?.dnsResolver) return Promise.resolve(options.dnsResolver);
+    if (!resolverPromise) resolverPromise = defaultDnsResolver();
+    return resolverPromise;
+  };
+
   return {
     name: 'WebFetch',
     description: 'Fetch content from a URL. Returns text content (HTML is stripped to plain text).',
@@ -87,6 +144,10 @@ export function createWebFetchTool(): AgentTool {
 
       const blocked = validateFetchUrl(url);
       if (blocked) return { content: blocked, isError: true };
+
+      const resolver = await getResolver();
+      const dnsBlocked = await checkDnsRebinding(url, resolver);
+      if (dnsBlocked) return { content: dnsBlocked, isError: true };
 
       try {
         // Follow redirects manually so each hop is validated against SSRF rules.

--- a/tests/unit/tools/builtin/web-fetch.test.ts
+++ b/tests/unit/tools/builtin/web-fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { createWebFetchTool } from '../../../../src/tools/builtin/web-fetch.js';
+import { createWebFetchTool, type DnsResolver } from '../../../../src/tools/builtin/web-fetch.js';
 
 describe('builtin/web-fetch', () => {
   const signal = new AbortController().signal;
@@ -145,6 +145,57 @@ describe('builtin/web-fetch', () => {
         const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
         expect(parsed.isError, `should block ${url}`).toBe(true);
       }
+    });
+
+    // --- issue #49: DNS rebinding mitigation ---
+
+    function mockDns(v4: string[], v6: string[] = []): DnsResolver {
+      return {
+        resolve4: vi.fn().mockResolvedValue(v4),
+        resolve6: vi.fn().mockResolvedValue(v6),
+      };
+    }
+    function failingDns(): DnsResolver {
+      return {
+        resolve4: vi.fn().mockRejectedValue(new Error('NXDOMAIN')),
+        resolve6: vi.fn().mockRejectedValue(new Error('NXDOMAIN')),
+      };
+    }
+
+    it('blocks hostname whose DNS resolves to cloud metadata IP (issue #49)', async () => {
+      const tool = createWebFetchTool({ dnsResolver: mockDns(['169.254.169.254']) });
+      const result = await tool.execute({ url: 'http://evil-rebind.com/' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/DNS|blocked|rebind/i);
+    });
+
+    it('blocks hostname whose DNS resolves to private 10.x.x.x range (issue #49)', async () => {
+      const tool = createWebFetchTool({ dnsResolver: mockDns(['10.0.0.1']) });
+      const result = await tool.execute({ url: 'http://internal.corp.example/' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('allows hostname whose DNS resolves to a public IP (issue #49)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('safe content', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+      );
+      const tool = createWebFetchTool({ dnsResolver: mockDns(['93.184.216.34']) });
+      const result = await tool.execute({ url: 'http://example.com/' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('safe content');
+    });
+
+    it('allows fetch when DNS lookup fails — fail-open (issue #49)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('ok', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+      );
+      const tool = createWebFetchTool({ dnsResolver: failingDns() });
+      const result = await tool.execute({ url: 'http://some-domain.example/' }, signal);
+      // DNS failure → fail-open → fetch proceeds
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('ok');
     });
 
     it('allows valid redirect to safe HTTPS URL', async () => {


### PR DESCRIPTION
## Issue
Closes #49

## Problema
`validateFetchUrl` valida o hostname **antes** da resolução DNS, mas `fetch()` resolve DNS em runtime. Um atacante pode registrar `evil.com` com TTL=1s apontando para IP público, passar na validação, e depois mudar o DNS para `169.254.169.254` (metadata AWS). A requisição real acessa o IP privado sem nova validação.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/web-fetch.test.ts` (4 novos testes `issue #49`)
- Falha antes do fix (red): sem pré-resolução, DNS rebinding não era detectado
- Implementação mínima em: `src/tools/builtin/web-fetch.ts`
  - `checkDnsRebinding(url, resolver)` pré-resolve e valida cada IP resolvido
  - `DnsResolver` interface injetável (evita mock de módulos nativos ESM)
  - Fail-open: DNS indisponível → fetch prossegue (preserva disponibilidade)
- Suíte completa: verde (4 falhas pré-existentes de issues #24/#27/#28 não relacionadas)

## Mudanças de regras (justificativa)
`createWebFetchTool` agora aceita `options?: { dnsResolver?: DnsResolver }` — adição backward-compatible, sem quebra de API existente.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_