### PR TITLE
fix: createFileReadTool aceita workingDir para path containment (closes #50)

### DIFF
--- a/src/tools/builtin/file-read.ts
+++ b/src/tools/builtin/file-read.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from 'node:fs/promises';
 import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
+import { assertSafePath } from './path-guard.js';
 
 const MAX_FILE_SIZE = 1_000_000; // 1MB
 const DEFAULT_LIMIT = 2000;
@@ -11,7 +12,7 @@ const FileReadParams = z.object({
   limit: z.number().optional().describe('Number of lines to read. Default: 2000'),
 });
 
-export function createFileReadTool(): AgentTool {
+export function createFileReadTool(workingDir?: string): AgentTool {
   return {
     name: 'Read',
     description: 'Read file contents with line numbers. Supports partial reads with offset and limit.',
@@ -22,6 +23,14 @@ export function createFileReadTool(): AgentTool {
 
     async execute(rawArgs: unknown) {
       const { file_path, offset, limit } = rawArgs as z.infer<typeof FileReadParams>;
+
+      if (workingDir) {
+        try {
+          assertSafePath(file_path, workingDir);
+        } catch (error) {
+          return { content: (error as Error).message, isError: true };
+        }
+      }
 
       try {
         const fileStat = await stat(file_path);

--- a/tests/unit/tools/builtin/file-read.test.ts
+++ b/tests/unit/tools/builtin/file-read.test.ts
@@ -54,4 +54,39 @@ describe('builtin/file-read', () => {
     const tool = createFileReadTool();
     expect(tool.getFilePath!({ file_path: '/foo/bar.ts' })).toBe('/foo/bar.ts');
   });
+
+  // --- issue #50: path containment for createFileReadTool ---
+
+  describe('workingDir path containment (issue #50)', () => {
+    it('blocks reading a file outside workingDir when workingDir is set', async () => {
+      const tool = createFileReadTool(tempDir);
+      const outsidePath = '/etc/passwd';
+      const result = await tool.execute({ file_path: outsidePath }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/traversal|outside|blocked/i);
+    });
+
+    it('allows reading a file inside workingDir when workingDir is set', async () => {
+      const tool = createFileReadTool(tempDir);
+      const result = await tool.execute({ file_path: join(tempDir, 'test.txt') }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('Line 1');
+    });
+
+    it('blocks path traversal via .. when workingDir is set', async () => {
+      const tool = createFileReadTool(tempDir);
+      const escapePath = join(tempDir, '..', 'secret.txt');
+      const result = await tool.execute({ file_path: escapePath }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('has no path restriction when workingDir is not set', async () => {
+      const tool = createFileReadTool(); // no restriction
+      const result = await tool.execute({ file_path: join(tempDir, 'test.txt') }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('Line 1');
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #50

## Problema
`createFileReadTool()` aceitava qualquer caminho absoluto sem restrição de diretório. Um agente podia ler `/etc/passwd`, `/proc/self/environ` (que expõe `apiKey`), `~/.ssh/id_rsa` etc. Ao contrário de `createFileWriteTool(workingDir?)` e `createFileEditTool(workingDir?)`, a ferramenta de leitura não oferecia essa proteção.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/file-read.test.ts` (suite `workingDir path containment`)
- Falha antes do fix (red): `createFileReadTool(tempDir)` não bloqueava `/etc/passwd`
- Implementação mínima em: `src/tools/builtin/file-read.ts` — adiciona parâmetro `workingDir?: string` e chama `assertSafePath` quando configurado, consistente com `createFileWriteTool`
- Suíte completa: verde (4 falhas pré-existentes de issues #24/#27/#28 não relacionadas)

## Mudanças de regras (justificativa)
Nenhuma — adição backward-compatible, assinatura anterior `createFileReadTool()` continua funcionando sem restrição.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_