### PR TITLE
fix: passa version via env: no release.yml evitando shell injection (closes #51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,19 +115,18 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-
           # Generate changelog from commits between previous tag and current
-          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${VERSION}$" | head -1 || echo "")
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${RELEASE_VERSION}$" | head -1 || echo "")
           if [ -z "$PREV_TAG" ]; then
-            NOTES=$(git log --format='- %s' "${VERSION}")
+            NOTES=$(git log --format='- %s' "${RELEASE_VERSION}")
           else
-            NOTES=$(git log --format='- %s' "${PREV_TAG}..${VERSION}")
+            NOTES=$(git log --format='- %s' "${PREV_TAG}..${RELEASE_VERSION}")
           fi
 
-          gh release create "$VERSION" \
-            --title "$VERSION" \
+          gh release create "$RELEASE_VERSION" \
+            --title "$RELEASE_VERSION" \
             --notes "$NOTES" \
             --target main \
             --latest

--- a/tests/unit/package-security.test.ts
+++ b/tests/unit/package-security.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as Record<string, unknown>;
+const releaseYml = readFileSync(resolve(__dirname, '../../.github/workflows/release.yml'), 'utf-8');
 
 describe('package.json security overrides (issue #26)', () => {
   it('should have a top-level "overrides" field for npm compatibility', () => {
@@ -29,5 +30,19 @@ describe('package.json security overrides (issue #26)', () => {
     const overrides = pkg['overrides'] as Record<string, string>;
     expect(overrides).toHaveProperty('postcss');
     expect(overrides['postcss']).toBe('>=8.5.10');
+  });
+});
+
+describe('release.yml shell injection hardening (issue #51)', () => {
+  it('does NOT interpolate ${{ steps.version.outputs.version }} directly in a run: shell command', () => {
+    // Direct interpolation: VERSION=${{ steps.version.outputs.version }} inside run: is a shell injection risk.
+    // The value must be passed via env: instead.
+    const directInterpolation = /VERSION=\$\{\{[^}]*steps\.version\.outputs\.version[^}]*\}\}/;
+    expect(releaseYml).not.toMatch(directInterpolation);
+  });
+
+  it('passes version to the release step via env: variable (not inline ${{ }})', () => {
+    // The release step should have RELEASE_VERSION (or similar) in its env: block
+    expect(releaseYml).toMatch(/RELEASE_VERSION:\s*\$\{\{[^}]*steps\.version\.outputs\.version/);
   });
 });


### PR DESCRIPTION
## Issue
Closes #51

## Problema
`VERSION=${{ steps.version.outputs.version }}` interpolava a saída do step diretamente em um comando shell. Valores passados via `${{ }}` em `run:` são processados pelo shell, expondo potencial CWE-78. Em produção o risco é baixo (output de `npm version` é controlado), mas é má prática documentada no GitHub Actions Security Hardening Guide.

## Abordagem TDD
- Teste em: `tests/unit/package-security.test.ts` (suite `release.yml shell injection hardening`)
- Falha antes do fix (red): regex detectava `VERSION=${{...}}` no YAML e ausência de `RELEASE_VERSION:` em `env:`
- Implementação mínima em: `.github/workflows/release.yml` — move `${{ steps.version.outputs.version }}` para `RELEASE_VERSION:` na chave `env:` do step; remove a linha de interpolação direta
- Suíte completa: verde (4 falhas pré-existentes de issues #24/#27/#28 não relacionadas)

## Mudanças de regras (justificativa)
Alteração em config de CI é estritamente essencial — a issue **é** o problema no CI.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Mudança de CI justificada (issue é o config de CI)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_