### PR TITLE
fix: emite logger.warn ao usar ConversationManager in-memory (closes #52)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -86,6 +86,10 @@ export class Agent {
       // Database will be initialized for knowledge, reuse it for conversations
       this.conversations = new ConversationManager(this.getDefaultConversationStore());
     } else {
+      this.logger.warn(
+        'knowledge.enabled=false: conversation history will not persist across restarts. ' +
+        'Pass conversation.store explicitly to enable persistence without knowledge.',
+      );
       this.conversations = new ConversationManager();
     }
 

--- a/tests/unit/agent.test.ts
+++ b/tests/unit/agent.test.ts
@@ -174,4 +174,43 @@ describe('Agent', () => {
     loadSpy.mockRestore();
     warnSpy.mockRestore();
   });
+
+  // --- issue #52: silent in-memory ConversationManager fallback ---
+
+  it('emits console.warn when knowledge.enabled=false and no conversation.store (issue #52)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    Agent.create({
+      apiKey: 'test-key',
+      logLevel: 'info',
+      knowledge: { enabled: false },
+      memory: { enabled: false },
+      // no conversation.store — should warn about non-persistent history
+    });
+
+    const persistenceWarn = warnSpy.mock.calls.find(
+      c => String(c[0]).toLowerCase().includes('persist') || String(c[0]).toLowerCase().includes('knowledge'),
+    );
+    expect(persistenceWarn).toBeDefined();
+    warnSpy.mockRestore();
+  });
+
+  it('does NOT warn when conversation.store is explicitly provided (issue #52)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mockStore = { getMessages: vi.fn(), addMessage: vi.fn(), getOrCreateThread: vi.fn(), clear: vi.fn() };
+
+    Agent.create({
+      apiKey: 'test-key',
+      logLevel: 'info',
+      knowledge: { enabled: false },
+      memory: { enabled: false },
+      conversation: { store: mockStore as any },
+    });
+
+    const persistenceWarn = warnSpy.mock.calls.find(
+      c => String(c[0]).toLowerCase().includes('persist') || String(c[0]).toLowerCase().includes('knowledge'),
+    );
+    expect(persistenceWarn).toBeUndefined();
+    warnSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Issue
Closes #52

## Problema
Quando `knowledge.enabled: false` e `conversation.store` não é fornecido, o `Agent` silenciosamente usava `ConversationManager()` in-memory. O histórico de conversas era perdido ao reiniciar o processo sem nenhum aviso — quebrando o Princípio do Menor Espanto (POLA): desabilitar RAG também desabilitava persistência de conversa, sem relação semântica óbvia.

## Abordagem TDD
- Teste em: `tests/unit/agent.test.ts` (2 novos testes `issue #52`)
- Falha antes do fix (red): `persistenceWarn` undefined — nenhum `console.warn` era emitido
- Implementação mínima em: `src/agent.ts` — adiciona `this.logger.warn(...)` antes de `new ConversationManager()` no ramo else (knowledge disabled, no store)
- Suíte completa: verde (4-5 falhas pré-existentes de issues #24/#27/#28 — #24 é flaky por race condition)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkhYuUvfbePYWoAUzANsf)_