### PR TITLE
fix: limita scan de vetores a MAX_SCAN=10_000 em SQLiteVectorStore (closes #60)

### DIFF
--- a/src/knowledge/sqlite-vector-store.ts
+++ b/src/knowledge/sqlite-vector-store.ts
@@ -2,6 +2,9 @@ import type { VectorStore } from '../contracts/entities/stores.js';
 import type { KnowledgeChunk, RetrievedKnowledge } from '../contracts/entities/knowledge.js';
 import type { SQLiteDatabase } from '../storage/sqlite-database.js';
 
+/** Maximum rows scanned per search call to bound memory usage. */
+const MAX_SCAN = 10_000;
+
 /**
  * SQLite implementation of VectorStore with brute-force cosine similarity.
  */
@@ -47,7 +50,9 @@ export class SQLiteVectorStore implements VectorStore {
   }
 
   search(queryEmbedding: Float32Array, topK: number): RetrievedKnowledge[] {
-    const rows = this.database.db.prepare('SELECT * FROM vectors').all() as VectorRow[];
+    const rows = this.database.db.prepare(
+      'SELECT * FROM vectors ORDER BY created_at DESC LIMIT ?'
+    ).all(MAX_SCAN) as VectorRow[];
 
     const scored = rows.map(row => {
       const embedding = new Float32Array(row.embedding.buffer, row.embedding.byteOffset, row.embedding.byteLength / 4);

--- a/tests/unit/knowledge/sqlite-vector-store.test.ts
+++ b/tests/unit/knowledge/sqlite-vector-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteDatabase } from '../../../src/storage/sqlite-database.js';
 import { SQLiteVectorStore } from '../../../src/knowledge/sqlite-vector-store.js';
 import type { KnowledgeChunk } from '../../../src/contracts/entities/knowledge.js';
@@ -78,5 +78,15 @@ describe('SQLiteVectorStore', () => {
     const results = store.search(query, 1);
     expect(results[0]!.score).toBeGreaterThanOrEqual(0);
     expect(results[0]!.score).toBeLessThanOrEqual(1);
+  });
+
+  it('search() uses a LIMIT clause to bound the number of scanned rows (#60)', () => {
+    const prepareSpy = vi.spyOn(database.db, 'prepare');
+    store.search(new Float32Array([1, 0, 0, 0]), 5);
+    const sqlCalls = prepareSpy.mock.calls.map(c => (c[0] as string).toUpperCase());
+    const scanSql = sqlCalls.find(sql => sql.includes('FROM VECTORS'));
+    expect(scanSql).toBeDefined();
+    expect(scanSql).toMatch(/LIMIT/);
+    prepareSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Issue
Closes #60

## Problema
`SQLiteVectorStore.search()` executava `SELECT * FROM vectors` sem nenhuma cláusula `LIMIT`, carregando **todos** os vetores em memória antes de calcular similaridade coseno. Para 10.000 chunks de 1536 dimensões cada (~6 KB/vetor), isso representa ~60 MB por chamada, proporcional ao total de vetores, não ao `topK`.

## Abordagem TDD
- Teste em: `tests/unit/knowledge/sqlite-vector-store.test.ts`
- Falha antes do fix (red): `expect(scanSql).toMatch(/LIMIT/)` — SQL era `SELECT * FROM VECTORS` sem LIMIT
- Implementação mínima em: `src/knowledge/sqlite-vector-store.ts`
  - Adicionado `MAX_SCAN = 10_000`
  - `search()` agora usa `SELECT * FROM vectors ORDER BY created_at DESC LIMIT ?`
- Suíte completa: verde (mesmas pré-existências, nenhuma nova falha)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug4mSLjv81WxmDU43bbcSj)_