### PR TITLE
fix: addTool retorna erro explícito para JSON malformado em StreamingToolExecutor (closes #61)

### DIFF
--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -51,7 +51,23 @@ export class StreamingToolExecutor {
   /** Called during LLM streaming when a tool_call chunk arrives */
   addTool(id: string, name: string, args: string): void {
     let parsedArgs: unknown;
-    try { parsedArgs = JSON.parse(args); } catch { parsedArgs = {}; }
+    try {
+      parsedArgs = JSON.parse(args);
+    } catch (e) {
+      this.tools.push({
+        id, name, args,
+        parsedArgs: {},
+        isSafe: true,
+        status: 'completed',
+        result: {
+          content: `Tool call arguments are not valid JSON: ${(e as Error).message}`,
+          isError: true,
+        },
+        duration: 0,
+        progressEvents: [],
+      });
+      return;
+    }
 
     const toolDef = this.executor.listTools().find(t => t.name === name);
     const isSafe = toolDef

--- a/tests/unit/core/streaming-tool-executor.test.ts
+++ b/tests/unit/core/streaming-tool-executor.test.ts
@@ -270,6 +270,29 @@ describe('StreamingToolExecutor', () => {
     expect(results).toHaveLength(2);
   });
 
+  it('should return error result for malformed JSON args instead of using {} (#61)', async () => {
+    const executor = new ToolExecutor();
+    const mockExecute = vi.fn().mockResolvedValue('should not be called');
+    executor.register(createTool({
+      name: 'my_tool',
+      execute: mockExecute,
+    }));
+
+    const streaming = new StreamingToolExecutor(executor);
+    streaming.addTool('c_bad', 'my_tool', '{invalid json{{');
+
+    const results: Array<{ id: string; result: { content: string; isError?: boolean } }> = [];
+    for await (const r of streaming.getRemainingResults()) {
+      results.push(r);
+    }
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe('c_bad');
+    expect(results[0]!.result.isError).toBe(true);
+    expect(results[0]!.result.content).toMatch(/JSON/i);
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
   it('should parse tool args exactly once per tool call (issue #3)', async () => {
     // Double JSON.parse wastes CPU and creates inconsistency when JSON is malformed.
     // parsedArgs computed in addTool() must be reused in executeTool() without re-parsing.


### PR DESCRIPTION
## Issue
Closes #61

## Problema
`StreamingToolExecutor.addTool()` silenciosamente substituía argumentos malformados por `{}` via `catch { parsedArgs = {}; }`, fazendo a tool ser executada com args inválidos. Isso tornava o erro de validação Zod downstream genérico ("campo obrigatório ausente") em vez de explícito ("JSON inválido"), e o JSON original corrompido era perdido.

## Abordagem TDD
- Teste em: `tests/unit/core/streaming-tool-executor.test.ts`
- Falha antes do fix (red): a tool era executada (`mockExecute` chamado) com `{}`, e o resultado não era `isError: true`
- Implementação mínima em: `src/core/streaming-tool-executor.ts`
  - No `catch`, push imediato de `TrackedTool` com `status: 'completed'` e `result.isError: true`, retornando sem enfileirar execução
- Suíte completa: verde (mesmas 4 pré-existências, +1 teste passando)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug4mSLjv81WxmDU43bbcSj)_