### PR TITLE
fix: REDOS_RISK cobre padrões de alternação com quantificador externo em grep.ts (closes #62)

### DIFF
--- a/src/tools/builtin/grep.ts
+++ b/src/tools/builtin/grep.ts
@@ -50,8 +50,9 @@ export function createGrepTool(): AgentTool {
       const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
 
       // Reject patterns that can cause catastrophic backtracking (ReDoS).
-      // Catches: quantified groups (a+)+, consecutive quantifiers a+*, quantified classes [a-z]*.
-      const REDOS_RISK = /(\(.*[+*?]\)|[+*?]{2,}|\[\^?.*\]\*)/;
+      // Catches: quantified groups (a+)+, consecutive quantifiers a+*, quantified classes [a-z]*,
+      // and alternation groups with external quantifier (a|ab)*.
+      const REDOS_RISK = /(\(.*[+*?]\)|[+*?]{2,}|\[\^?.*\]\*|\([^)]*\|[^)]*\)[+*?{])/;
       if (REDOS_RISK.test(pattern)) {
         return { content: 'Pattern too complex — potential ReDoS risk', isError: true };
       }

--- a/tests/unit/tools/builtin/grep.test.ts
+++ b/tests/unit/tools/builtin/grep.test.ts
@@ -95,4 +95,28 @@ describe('builtin/grep', () => {
       expect(parsed.isError).toBeFalsy();
     });
   });
+
+  describe('ReDoS protection — alternation with external quantifier (issue #62)', () => {
+    it('should reject (a|ab)*b — alternation group with * quantifier', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: '(a|ab)*b', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/complex|ReDoS/i);
+    });
+
+    it('should reject (a|a)+ — alternation group with + quantifier', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: '(a|a)+', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('should still accept (foo|bar) without external quantifier', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: '(function|class)', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #62

## Problema
A regex `REDOS_RISK` em `grep.ts` não detectava padrões de alternação com quantificador externo como `(a|ab)*b` ou `(a|a)+`. Esses padrões causam backtracking exponencial ("catastrophic backtracking") em inputs adversariais, bloqueando o event loop do Node.js sem preempção.

A regex anterior cobria apenas:
- Grupos com quantificadores internos: `(a+)+`
- Quantificadores consecutivos: `a+*`
- Classes quantificadas: `[a-z]*`

Mas **não** cobria: `(a|b)*`, `(a|b)+`, `(a|b){n,m}`.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/grep.test.ts` (describe `ReDoS protection — alternation with external quantifier (issue #62)`)
- Falha antes do fix (red): `(a|ab)*b` e `(a|a)+` executavam sem ser rejeitados
- Implementação mínima em: `src/tools/builtin/grep.ts`
  - Adicionado `\([^)]*\|[^)]*\)[+*?{]` à regex `REDOS_RISK`
  - Captura grupos com `|` seguidos de quantificador externo `+`, `*`, `?` ou `{`
  - Não gera falsos positivos: `(function|class)` sem quantificador externo é aceito
- Suíte completa: verde (mesmas pré-existências, nenhuma nova falha)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug4mSLjv81WxmDU43bbcSj)_