### PR TITLE
fix: SQLiteConversationStore aceita Logger injetável, usa logger.warn no catch (closes #63)

### DIFF
--- a/src/storage/sqlite-conversation-store.ts
+++ b/src/storage/sqlite-conversation-store.ts
@@ -1,15 +1,19 @@
 import type { ConversationStore } from '../contracts/entities/stores.js';
 import type { ChatMessage } from '../contracts/entities/chat-message.js';
 import type { SQLiteDatabase } from './sqlite-database.js';
+import { createLogger } from '../utils/logger.js';
+import type { Logger } from '../utils/logger.js';
 
 /**
  * SQLite implementation of ConversationStore.
  */
 export class SQLiteConversationStore implements ConversationStore {
   private readonly database: SQLiteDatabase;
+  private readonly logger: Logger;
 
-  constructor(database: SQLiteDatabase) {
+  constructor(database: SQLiteDatabase, logger?: Logger) {
     this.database = database;
+    this.logger = logger ?? createLogger({ level: 'warn', prefix: 'SQLiteConversationStore' });
   }
 
   appendMessage(message: ChatMessage, threadId: string): void {
@@ -31,14 +35,14 @@ export class SQLiteConversationStore implements ConversationStore {
     const rows = this.database.db.prepare(
       'SELECT * FROM conversations WHERE thread_id = ? ORDER BY created_at ASC'
     ).all(threadId) as ConversationRow[];
-    return rows.map(rowToMessage);
+    return rows.map(row => rowToMessage(row, this.logger));
   }
 
   listPinned(threadId: string): ChatMessage[] {
     const rows = this.database.db.prepare(
       'SELECT * FROM conversations WHERE thread_id = ? AND pinned = 1 ORDER BY created_at ASC'
     ).all(threadId) as ConversationRow[];
-    return rows.map(rowToMessage);
+    return rows.map(row => rowToMessage(row, this.logger));
   }
 
   clearThread(threadId: string): void {
@@ -48,7 +52,7 @@ export class SQLiteConversationStore implements ConversationStore {
 
 const VALID_ROLES = new Set<string>(['user', 'assistant', 'system', 'tool']);
 
-function rowToMessage(row: ConversationRow): ChatMessage {
+function rowToMessage(row: ConversationRow, logger: Logger): ChatMessage {
   if (!VALID_ROLES.has(row.role)) {
     throw new Error(`Invalid message role in database: "${row.role}"`);
   }
@@ -66,7 +70,11 @@ function rowToMessage(row: ConversationRow): ChatMessage {
     try {
       toolCalls = JSON.parse(row.tool_calls);
     } catch (e) {
-      console.warn(`[SQLiteConversationStore] Invalid tool_calls JSON — row.id=${row.id}, thread=${row.thread_id}`, e);
+      logger.warn('Invalid tool_calls JSON in conversations table', {
+        rowId: row.id,
+        threadId: row.thread_id,
+        error: e instanceof Error ? e.message : String(e),
+      });
       toolCalls = undefined;
     }
   }

--- a/tests/unit/storage/sqlite-conversation-store.test.ts
+++ b/tests/unit/storage/sqlite-conversation-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteDatabase } from '../../../src/storage/sqlite-database.js';
 import { SQLiteConversationStore } from '../../../src/storage/sqlite-conversation-store.js';
 import type { ChatMessage } from '../../../src/contracts/entities/chat-message.js';
+import type { Logger } from '../../../src/utils/logger.js';
 
 function msg(role: ChatMessage['role'], content: string, pinned = false): ChatMessage {
   return { role, content, pinned, createdAt: Date.now() };
@@ -134,5 +135,32 @@ describe('SQLiteConversationStore', () => {
     expect(messages[0]!.content).toBe('first');
     expect(messages[1]!.content).toBe('second');
     expect(messages[2]!.content).toBe('third');
+  });
+
+  it('should use injected logger.warn instead of console.warn directly (#63)', () => {
+    const warnMessages: string[] = [];
+    const customLogger: Logger = {
+      level: 'silent',
+      debug: () => {},
+      info: () => {},
+      warn: (msg: string) => { warnMessages.push(msg); },
+      error: () => {},
+      child: () => customLogger,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storeWithLogger = new (SQLiteConversationStore as any)(database, customLogger) as SQLiteConversationStore;
+    database.db.prepare(`
+      INSERT INTO conversations (thread_id, role, content, tool_calls, tool_call_id, pinned, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('t-custom-logger', 'assistant', '""', 'NOT_VALID_JSON', null, 0, Date.now());
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    storeWithLogger.listThread('t-custom-logger');
+    const consoleWarnCalled = consoleSpy.mock.calls.length > 0;
+    consoleSpy.mockRestore();
+
+    expect(consoleWarnCalled).toBe(false);
+    expect(warnMessages).toHaveLength(1);
+    expect(warnMessages[0]).toMatch(/tool_calls/i);
   });
 });


### PR DESCRIPTION
## Issue
Closes #63

## Problema
`SQLiteConversationStore` chamava `console.warn()` diretamente ao encontrar `tool_calls` JSON inválido na tabela `conversations`. Esse `console.warn` não podia ser suprimido nem redirecionado — aparecia em `stderr` mesmo quando o usuário configurava `level: 'silent'` ou `level: 'error'`, violando o princípio de Observabilidade Consistente do SDK.

## Abordagem TDD
- Teste em: `tests/unit/storage/sqlite-conversation-store.test.ts`
- Falha antes do fix (red): ao injetar um logger customizado (level `silent`), `console.warn` ainda era chamado e o logger não recebia nada
- Implementação mínima em: `src/storage/sqlite-conversation-store.ts`
  - Adicionados imports de `Logger` e `createLogger` de `utils/logger`
  - Constructor aceita `logger?: Logger` (backwards-compatible)
  - Default: `createLogger({ level: 'warn', prefix: 'SQLiteConversationStore' })` — mantém comportamento existente
  - `rowToMessage` recebe logger por parâmetro e usa `logger.warn()` em vez de `console.warn()`
- Teste existente "should warn via console.warn (issue #25)": **continua passando** — o logger default chama `console.warn` internamente com a mensagem formatada que contém "SQLiteConversationStore" e "tool_calls"
- Suíte completa: verde (mesmas 4 pré-existências, +1 teste passando)

## Mudanças de regras (justificativa)
Nenhuma. O parâmetro `logger` é opcional, mantendo compatibilidade com todos os call sites existentes.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug4mSLjv81WxmDU43bbcSj)_