### PR TITLE
fix: adiciona path containment ao createGrepTool (closes #68)

### DIFF
--- a/src/tools/builtin/grep.ts
+++ b/src/tools/builtin/grep.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
 import { matchGlob } from '../../skills/skill-glob.js';
+import { assertSafePath } from './path-guard.js';
 
 const DEFAULT_MAX_RESULTS = 50;
 
@@ -36,7 +37,7 @@ async function collectFiles(dir: string, globPattern?: string): Promise<string[]
   return results;
 }
 
-export function createGrepTool(): AgentTool {
+export function createGrepTool(workingDir?: string): AgentTool {
   return {
     name: 'Grep',
     description: 'Search file contents using regex. Returns matching lines with file paths and line numbers.',
@@ -46,7 +47,16 @@ export function createGrepTool(): AgentTool {
 
     async execute(rawArgs: unknown, signal: AbortSignal) {
       const { pattern, path: searchPath, glob: globFilter, max_results } = rawArgs as z.infer<typeof GrepParams>;
-      const baseDir = searchPath || process.cwd();
+
+      if (workingDir && searchPath) {
+        try {
+          assertSafePath(searchPath, workingDir);
+        } catch (error) {
+          return { content: (error as Error).message, isError: true };
+        }
+      }
+
+      const baseDir = searchPath || workingDir || process.cwd();
       const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
 
       // Reject patterns that can cause catastrophic backtracking (ReDoS).

--- a/tests/unit/tools/builtin/grep.test.ts
+++ b/tests/unit/tools/builtin/grep.test.ts
@@ -58,6 +58,38 @@ describe('builtin/grep', () => {
     expect(lines.length).toBeLessThanOrEqual(2); // 1 match + possible context
   });
 
+  describe('path containment (issue #68)', () => {
+    it('should block path outside workingDir when workingDir is set', async () => {
+      const tool = createGrepTool(tempDir);
+      const outsideDir = tmpdir();
+      const result = await tool.execute({ pattern: 'root', path: outsideDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/traversal|outside|blocked/i);
+    });
+
+    it('should allow path inside workingDir when workingDir is set', async () => {
+      const tool = createGrepTool(tempDir);
+      const result = await tool.execute({ pattern: 'function', path: join(tempDir, 'src') }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+
+    it('should default to workingDir when no path is given and workingDir is set', async () => {
+      const tool = createGrepTool(tempDir);
+      const result = await tool.execute({ pattern: 'function' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('index.ts');
+    });
+
+    it('should be backward compatible when no workingDir is set', async () => {
+      const tool = createGrepTool();
+      const result = await tool.execute({ pattern: 'function', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+  });
+
   describe('ReDoS protection (issue #7)', () => {
     it('should reject patterns with nested quantifiers like (a+)+', async () => {
       const tool = createGrepTool();


### PR DESCRIPTION
## Issue
Closes #68

## Problema
`createGrepTool()` aceitava qualquer caminho absoluto no parâmetro `path` sem restrição de diretório, permitindo que um agente lesse conteúdo de arquivos fora do diretório de trabalho (path traversal / exfiltração de dados).

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/grep.test.ts` (bloco `path containment (issue #68)`)
- Falha antes do fix (red): 2 testes falhavam — bloqueio de path externo e default para workingDir
- Implementação mínima em: `src/tools/builtin/grep.ts`
  - `createGrepTool(workingDir?: string)` — parâmetro opcional, 100% backward compatible
  - `assertSafePath(searchPath, workingDir)` aplicado antes da execução quando ambos estão configurados
  - `baseDir` passa a usar `workingDir` como fallback antes de `process.cwd()`
- Suíte completa: verde (falhas pré-existentes não relacionadas a esta mudança)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVneNDycLVrR5qPzYLDe9K)_