### PR TITLE
fix: builtinTools.all/fileOps propagam workingDir para Write e Edit (closes #69)

### DIFF
--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -36,24 +36,24 @@ export const builtinTools = {
   askUser: createAskUserTool,
 
   /** All tools except askUser (which needs a callback) */
-  all(): AgentTool[] {
+  all(workingDir?: string): AgentTool[] {
     return [
       createGlobTool(),
       createGrepTool(),
       createFileReadTool(),
-      createFileWriteTool(),
-      createFileEditTool(),
+      createFileWriteTool(workingDir),
+      createFileEditTool(workingDir),
       createBashTool(),
       createWebFetchTool(),
     ];
   },
 
   /** File operation tools: read + write + edit + glob + grep */
-  fileOps(): AgentTool[] {
+  fileOps(workingDir?: string): AgentTool[] {
     return [
       createFileReadTool(),
-      createFileWriteTool(),
-      createFileEditTool(),
+      createFileWriteTool(workingDir),
+      createFileEditTool(workingDir),
       createGlobTool(),
       createGrepTool(),
     ];

--- a/tests/unit/tools/builtin/integration.test.ts
+++ b/tests/unit/tools/builtin/integration.test.ts
@@ -1,10 +1,84 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { ToolExecutor } from '../../../../src/tools/tool-executor.js';
 import { builtinTools } from '../../../../src/tools/builtin/index.js';
 import { Agent } from '../../../../src/agent.js';
 
 describe('Builtin tools integration', () => {
   afterEach(() => { vi.restoreAllMocks(); });
+
+  describe('path containment via workingDir (issue #69)', () => {
+    let workingDir: string;
+
+    beforeEach(async () => {
+      workingDir = await mkdtemp(join(tmpdir(), 'builtin-all-'));
+      await writeFile(join(workingDir, 'file.txt'), 'hello');
+    });
+
+    afterEach(async () => {
+      await rm(workingDir, { recursive: true, force: true });
+    });
+
+    it('all(workingDir) — Write tool blocks paths outside workingDir', async () => {
+      const executor = new ToolExecutor();
+      builtinTools.all(workingDir).forEach(t => executor.register(t));
+
+      const result = await executor.execute('Write', {
+        file_path: join(tmpdir(), 'escaped.txt'),
+        content: 'bad',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/traversal|outside|blocked/i);
+    });
+
+    it('all(workingDir) — Write tool allows paths inside workingDir', async () => {
+      const executor = new ToolExecutor();
+      builtinTools.all(workingDir).forEach(t => executor.register(t));
+
+      const result = await executor.execute('Write', {
+        file_path: join(workingDir, 'safe.txt'),
+        content: 'ok',
+      });
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('all(workingDir) — Edit tool blocks paths outside workingDir', async () => {
+      const executor = new ToolExecutor();
+      builtinTools.all(workingDir).forEach(t => executor.register(t));
+
+      const result = await executor.execute('Edit', {
+        file_path: join(tmpdir(), 'escaped.txt'),
+        old_string: 'hello',
+        new_string: 'world',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/traversal|outside|blocked/i);
+    });
+
+    it('all() without workingDir remains backward compatible', async () => {
+      const executor = new ToolExecutor();
+      builtinTools.all().forEach(t => executor.register(t));
+
+      const result = await executor.execute('Write', {
+        file_path: join(workingDir, 'compat.txt'),
+        content: 'ok',
+      });
+      expect(result.isError).toBeFalsy();
+    });
+
+    it('fileOps(workingDir) — Write tool enforces containment', async () => {
+      const executor = new ToolExecutor();
+      builtinTools.fileOps(workingDir).forEach(t => executor.register(t));
+
+      const result = await executor.execute('Write', {
+        file_path: join(tmpdir(), 'escaped.txt'),
+        content: 'bad',
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
 
   it('should register all tools and generate valid JSON Schema for LLM', () => {
     const executor = new ToolExecutor();


### PR DESCRIPTION
## Issue
Closes #69

## Problema
`builtinTools.all()` e `builtinTools.fileOps()` chamavam `createFileWriteTool()` e `createFileEditTool()` sem o parâmetro `workingDir`, fazendo com que a proteção de path containment (que já existia nesses tools) ficasse inativa. Um agente podia escrever em qualquer caminho do filesystem via `builtinTools.all()`.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/integration.test.ts` (bloco `path containment via workingDir (issue #69)`)
- Falha antes do fix (red): 3 testes falhavam — Write bloqueado fora de workingDir, Edit bloqueado, fileOps com containment
- Implementação mínima em: `src/tools/builtin/index.ts`
  - `all(workingDir?: string)` — aceita workingDir opcional e passa para Write e Edit
  - `fileOps(workingDir?: string)` — mesmo padrão
  - 100% backward compatible: sem workingDir, comportamento idêntico ao anterior
- Suíte completa: verde (falhas pré-existentes não relacionadas)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVneNDycLVrR5qPzYLDe9K)_