### PR TITLE
fix: adiciona path containment ao createGlobTool (closes #70)

### DIFF
--- a/src/tools/builtin/glob.ts
+++ b/src/tools/builtin/glob.ts
@@ -3,6 +3,7 @@ import { join, relative, sep } from 'node:path';
 import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
 import { matchGlob } from '../../skills/skill-glob.js';
+import { assertSafePath } from './path-guard.js';
 
 const MAX_RESULTS = 100;
 
@@ -24,7 +25,7 @@ async function walkDir(dir: string, results: string[]): Promise<void> {
   }
 }
 
-export function createGlobTool(): AgentTool {
+export function createGlobTool(workingDir?: string): AgentTool {
   return {
     name: 'Glob',
     description: 'Fast file pattern matching. Returns matching file paths sorted by modification time.',
@@ -34,7 +35,16 @@ export function createGlobTool(): AgentTool {
 
     async execute(rawArgs: unknown, _signal: AbortSignal) {
       const { pattern, path: searchPath } = rawArgs as z.infer<typeof GlobParams>;
-      const baseDir = searchPath || process.cwd();
+
+      if (workingDir && searchPath) {
+        try {
+          assertSafePath(searchPath, workingDir);
+        } catch (error) {
+          return { content: (error as Error).message, isError: true };
+        }
+      }
+
+      const baseDir = searchPath || workingDir || process.cwd();
 
       const allFiles: string[] = [];
       try {

--- a/tests/unit/tools/builtin/glob.test.ts
+++ b/tests/unit/tools/builtin/glob.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createGlobTool } from '../../../../src/tools/builtin/glob.js';
 
+
 describe('builtin/glob', () => {
   let tempDir: string;
   const signal = new AbortController().signal;
@@ -49,5 +50,37 @@ describe('builtin/glob', () => {
     const result = await tool.execute({ pattern: '**/*.py', path: tempDir }, signal);
     const content = typeof result === 'string' ? result : result.content;
     expect(content).toContain('No files found');
+  });
+
+  describe('path containment (issue #70)', () => {
+    it('should block path outside workingDir when workingDir is set', async () => {
+      const tool = createGlobTool(tempDir);
+      const outsideDir = tmpdir();
+      const result = await tool.execute({ pattern: '**/*', path: outsideDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/traversal|outside|blocked/i);
+    });
+
+    it('should allow path inside workingDir when workingDir is set', async () => {
+      const tool = createGlobTool(tempDir);
+      const result = await tool.execute({ pattern: '**/*.ts', path: join(tempDir, 'src') }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
+
+    it('should default to workingDir when no path is given and workingDir is set', async () => {
+      const tool = createGlobTool(tempDir);
+      const result = await tool.execute({ pattern: '**/*.ts' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('index.ts');
+    });
+
+    it('should be backward compatible when no workingDir is set', async () => {
+      const tool = createGlobTool();
+      const result = await tool.execute({ pattern: '**/*.ts', path: tempDir }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
## Issue
Closes #70

## Problema
`createGlobTool()` aceitava qualquer caminho absoluto no parâmetro `path` sem restrição de diretório. Ao contrário de `createFileWriteTool` e `createFileEditTool`, o Glob não tinha o parâmetro `workingDir` nem mesmo como opção. Um agente podia listar arquivos de qualquer diretório do sistema (path traversal / divulgação de estrutura de arquivos).

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/glob.test.ts` (bloco `path containment (issue #70)`)
- Falha antes do fix (red): 2 testes falhavam — bloqueio de path externo e default para workingDir
- Implementação mínima em: `src/tools/builtin/glob.ts`
  - `createGlobTool(workingDir?: string)` — parâmetro opcional, 100% backward compatible
  - `assertSafePath(searchPath, workingDir)` aplicado antes da execução quando ambos estão configurados
  - `baseDir` passa a usar `workingDir` como fallback antes de `process.cwd()`
- Suíte completa: verde (falhas pré-existentes não relacionadas a esta mudança)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVneNDycLVrR5qPzYLDe9K)_