### PR TITLE
fix: streaming reader com hard limit 10 MB em WebFetch — evita DoS via corpo grande (closes #77)

### DIFF
--- a/src/tools/builtin/web-fetch.ts
+++ b/src/tools/builtin/web-fetch.ts
@@ -3,6 +3,7 @@ import type { AgentTool } from '../../contracts/entities/agent-tool.js';
 
 const DEFAULT_MAX_CHARS = 50_000;
 const MAX_REDIRECT_HOPS = 5;
+const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB hard limit — prevents OOM via large responses
 
 /** Validate URL against SSRF attack vectors. Returns null if safe, error message if blocked. */
 function validateFetchUrl(rawUrl: string): string | null {
@@ -123,6 +124,42 @@ function stripHtml(html: string): string {
     .trim();
 }
 
+/**
+ * Read the response body via a streaming reader, stopping at MAX_BODY_BYTES.
+ * This prevents OOM when a server returns a very large or infinite body.
+ */
+async function readBodyWithLimit(response: Response): Promise<{ text: string; truncatedByBytes: boolean }> {
+  if (!response.body) {
+    return { text: '', truncatedByBytes: false };
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let bytesRead = 0;
+  let truncatedByBytes = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      text += decoder.decode(value, { stream: true });
+      if (bytesRead >= MAX_BODY_BYTES) {
+        await reader.cancel();
+        truncatedByBytes = true;
+        break;
+      }
+    }
+    // Flush any remaining bytes in the decoder
+    text += decoder.decode();
+  } catch {
+    // Partial read is acceptable; return what we have
+  }
+
+  return { text, truncatedByBytes };
+}
+
 export function createWebFetchTool(options?: { dnsResolver?: DnsResolver }): AgentTool {
   let resolverPromise: Promise<DnsResolver> | null = null;
   const getResolver = (): Promise<DnsResolver> => {
@@ -191,13 +228,16 @@ export function createWebFetchTool(options?: { dnsResolver?: DnsResolver }): Age
         }
 
         const contentType = response.headers.get('content-type') ?? '';
-        let text = await response.text();
+        const { text: rawText, truncatedByBytes } = await readBodyWithLimit(response);
 
+        let text = rawText;
         if (contentType.includes('text/html')) {
           text = stripHtml(text);
         }
 
-        if (text.length > maxChars) {
+        if (truncatedByBytes) {
+          text = text.slice(0, maxChars) + `\n\n[truncated — body size limit reached]`;
+        } else if (text.length > maxChars) {
           text = text.slice(0, maxChars) + `\n\n[truncated — ${text.length - maxChars} characters omitted]`;
         }
 

--- a/tests/unit/tools/builtin/web-fetch.test.ts
+++ b/tests/unit/tools/builtin/web-fetch.test.ts
@@ -65,6 +65,52 @@ describe('builtin/web-fetch', () => {
     expect(parsed.isError).toBe(true);
   });
 
+  // --- issue #77: hard body-size limit via streaming reader ---
+
+  it('stops reading after 10 MB hard limit without buffering the full body (#77)', async () => {
+    const CHUNK_SIZE = 1024 * 1024; // 1 MB per chunk
+    const chunk = new Uint8Array(CHUNK_SIZE).fill(65); // fill with 'A'
+    const TOTAL_CHUNKS = 15; // 15 MB total available
+    let chunksDelivered = 0;
+
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (chunksDelivered < TOTAL_CHUNKS) {
+          controller.enqueue(chunk);
+          chunksDelivered++;
+        } else {
+          controller.close();
+        }
+      },
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(stream, { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    const tool = createWebFetchTool();
+    const result = await tool.execute({ url: 'https://example.com/huge' }, signal);
+    const content = typeof result === 'string' ? result : (result as { content: string }).content;
+
+    // Must include truncation notice
+    expect(content).toMatch(/truncated/);
+    // Must NOT have consumed all 15 MB — reading should stop at the 10 MB limit
+    expect(chunksDelivered).toBeLessThanOrEqual(10);
+  });
+
+  it('returns error when response body is not readable (#77)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    );
+
+    const tool = createWebFetchTool();
+    const result = await tool.execute({ url: 'https://example.com/no-body' }, signal);
+    // null body: either treated as empty string or returns error — both acceptable
+    expect(result).toBeDefined();
+  });
+
+  // --- end issue #77 ---
+
   describe('SSRF protection', () => {
     const tool = createWebFetchTool();
 
@@ -97,8 +143,6 @@ describe('builtin/web-fetch', () => {
         expect(parsed.isError, `should block ${url}`).toBe(true);
       }
     });
-
-    // --- issue #21: redirect bypass and IPv6 private ranges ---
 
     it('blocks redirect to internal IPv4 (SSRF via redirect)', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
@@ -147,8 +191,6 @@ describe('builtin/web-fetch', () => {
       }
     });
 
-    // --- issue #49: DNS rebinding mitigation ---
-
     function mockDns(v4: string[], v6: string[] = []): DnsResolver {
       return {
         resolve4: vi.fn().mockResolvedValue(v4),
@@ -193,7 +235,6 @@ describe('builtin/web-fetch', () => {
       );
       const tool = createWebFetchTool({ dnsResolver: failingDns() });
       const result = await tool.execute({ url: 'http://some-domain.example/' }, signal);
-      // DNS failure → fail-open → fetch proceeds
       const content = typeof result === 'string' ? result : result.content;
       expect(content).toContain('ok');
     });


### PR DESCRIPTION
## Issue\nCloses #77\n\n## Problema\n`response.text()` bufferizava o corpo HTTP inteiro na memória antes de aplicar `maxChars`. Um servidor retornando 500 MB causaria OOM no processo Node.js antes de qualquer truncação.\n\n## Abordagem TDD\n- Teste em: `tests/unit/tools/builtin/web-fetch.test.ts` (2 novos testes: hard limit via stream de 15 MB, corpo null)\n- Falha antes do fix (red): `chunksDelivered` seria 15 (todos os chunks lidos) — esperava `<= 10`\n- Implementação mínima em: `src/tools/builtin/web-fetch.ts` — `readBodyWithLimit()` usa `ReadableStreamDefaultReader`, cancela após `MAX_BODY_BYTES = 10 MB`\n- Suíte completa: verde\n\n## Mudanças de regras (justificativa)\nNenhuma.\n\n## Checklist\n- [x] Teste antes do fix\n- [x] Suíte verde\n- [x] Sem mudança de regras existentes (ou justificada)\n\n---\n_Generated by [Claude Code](https://claude.ai/code/session_015zoqZkjWU5xNodBkDjY7GG)_