### PR TITLE
fix: MAX_PROPERTIES=500 e MAX_UNION_MEMBERS=50 em jsonSchemaToZod — proteção DoS via MCP malicioso (closes #78)

### DIFF
--- a/src/tools/json-schema-to-zod.ts
+++ b/src/tools/json-schema-to-zod.ts
@@ -12,6 +12,10 @@ import { z } from 'zod';
 
 const MAX_DEPTH = 10;
 
+/** Hard caps against DoS via malicious MCP schemas with huge property counts. */
+const MAX_PROPERTIES = 500;
+const MAX_UNION_MEMBERS = 50;
+
 type JsonSchema = {
   type?: string;
   properties?: Record<string, JsonSchema>;
@@ -94,10 +98,12 @@ export function jsonSchemaToZod(schema?: JsonSchema | null, depth = 0): z.ZodTyp
 function buildObject(schema: JsonSchema, depth: number): z.ZodTypeAny {
   if (!schema.properties) return z.object({}).passthrough();
 
-  const required = new Set(schema.required ?? []);
+  // Limit entries and required set to prevent DoS via malicious MCP schemas.
+  const entries = Object.entries(schema.properties).slice(0, MAX_PROPERTIES);
+  const required = new Set((schema.required ?? []).slice(0, MAX_PROPERTIES));
   const shape: Record<string, z.ZodTypeAny> = {};
 
-  for (const [key, propSchema] of Object.entries(schema.properties)) {
+  for (const [key, propSchema] of entries) {
     let field = jsonSchemaToZod(propSchema, depth + 1);
     if (!required.has(key)) {
       field = field.optional();
@@ -133,7 +139,9 @@ function buildEnum(values: unknown[], nullable?: boolean): z.ZodTypeAny {
 }
 
 function buildUnion(schemas: JsonSchema[], depth: number): z.ZodTypeAny {
-  const members = schemas.map(s => jsonSchemaToZod(s, depth + 1));
+  // Limit members to prevent DoS via malicious MCP schemas with huge anyOf/oneOf arrays.
+  const limited = schemas.slice(0, MAX_UNION_MEMBERS);
+  const members = limited.map(s => jsonSchemaToZod(s, depth + 1));
   if (members.length >= 2) {
     return z.union(members as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
   }

--- a/tests/unit/tools/json-schema-to-zod.test.ts
+++ b/tests/unit/tools/json-schema-to-zod.test.ts
@@ -171,4 +171,49 @@ describe('jsonSchemaToZod (deep)', () => {
     // Should produce a valid schema (deep nesting falls back to z.unknown)
     expect(schema).toBeDefined();
   });
+
+  // --- issue #78: DoS protection — MAX_PROPERTIES and MAX_UNION_MEMBERS limits ---
+
+  it('limits required properties beyond MAX_PROPERTIES (501st required prop is not enforced) (#78)', () => {
+    const MAX_PROPERTIES = 500;
+    const props: Record<string, { type: string }> = {};
+    const required: string[] = [];
+    for (let i = 0; i <= MAX_PROPERTIES; i++) {
+      const key = `p${String(i).padStart(6, '0')}`;
+      props[key] = { type: 'string' };
+      required.push(key);
+    }
+
+    const schema = jsonSchemaToZod({ type: 'object', properties: props, required });
+
+    // Build input with only the first MAX_PROPERTIES keys (omitting p000500)
+    const input: Record<string, string> = {};
+    for (let i = 0; i < MAX_PROPERTIES; i++) {
+      input[`p${String(i).padStart(6, '0')}`] = 'x';
+    }
+
+    // Without the fix: parse throws because p000500 is required.
+    // With the fix: p000500 is beyond the limit so it is not in the shape.
+    expect(() => schema.parse(input)).not.toThrow();
+  });
+
+  it('limits anyOf members to MAX_UNION_MEMBERS (51st member is excluded from union) (#78)', () => {
+    const MAX_UNION_MEMBERS = 50;
+    // Build 51 single-value enum schemas: value0 .. value50
+    const schemas = Array.from({ length: MAX_UNION_MEMBERS + 1 }, (_, i) => ({
+      enum: [`value${i}`],
+    }));
+
+    const schema = jsonSchemaToZod({ anyOf: schemas });
+
+    // First value is within the limit — must be valid
+    expect(schema.parse('value0')).toBe('value0');
+
+    // 51st value is beyond the limit — must be rejected by the union
+    // Without the fix: all 51 members included, so value50 is valid.
+    // With the fix: only first 50 members included, so value50 is invalid.
+    expect(() => schema.parse('value50')).toThrow();
+  });
+
+  // --- end issue #78 ---
 });


### PR DESCRIPTION
## Issue\nCloses #78\n\n## Problema\n`buildObject` iterava `schema.properties` sem limite. Um servidor MCP malicioso com 1 000 000 de propriedades consumia ~1 GB de memória e bloqueava o event loop por 60s+. O mesmo valia para `buildUnion` com `anyOf`/`oneOf` gigantes.\n\n## Abordagem TDD\n- Teste em: `tests/unit/tools/json-schema-to-zod.test.ts` (2 novos testes)\n  - **Propriedades**: 501 props todas required → sem fix, parse falha (501ª é required); com fix, 501ª não está no shape → parse passa\n  - **Union**: 51 membros enum → sem fix, `value50` é válido; com fix, só primeiros 50 → `value50` é rejeitado\n- Falha antes do fix (red): ambos os testes falham com o código atual\n- Implementação mínima em: `src/tools/json-schema-to-zod.ts` — `MAX_PROPERTIES = 500`, `MAX_UNION_MEMBERS = 50`\n- Suíte completa: verde\n\n## Mudanças de regras (justificativa)\nNenhuma.\n\n## Checklist\n- [x] Teste antes do fix\n- [x] Suíte verde\n- [x] Sem mudança de regras existentes (ou justificada)\n\n---\n_Generated by [Claude Code](https://claude.ai/code/session_015zoqZkjWU5xNodBkDjY7GG)_