### PR TITLE
fix(llm): captura usage do streaming via stream_options.include_usage

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -71,6 +71,10 @@ export class LLMClient {
       model,
       messages,
       stream: true,
+      // OpenAI-compatible providers (OpenAI, OpenRouter, LiteLLM, vLLM) only emit
+      // usage on the SSE stream when this flag is set. Without it, the final chunk
+      // has finish_reason but no token counts — costs cannot be computed downstream.
+      stream_options: { include_usage: true },
       ...reasoningArgs,
     };
 
@@ -222,6 +226,14 @@ export class LLMClient {
     // Accumulate tool calls incrementally
     const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
 
+    // Defer the `done` event until end-of-stream. With stream_options.include_usage,
+    // OpenAI-compatible providers send usage in a SEPARATE chunk (with empty choices)
+    // AFTER the chunk that carried finish_reason. If we emitted `done` on
+    // finish_reason like before, we'd race ahead of the usage chunk and lose it.
+    let pendingFinishReason: string | undefined;
+    let pendingUsage: TokenUsage | undefined;
+    let donePending = false;
+
     // Propagate abort to the reader so a hanging read() is unblocked immediately.
     const abortHandler = (): void => { void reader.cancel().catch(() => {}); };
     if (signal) {
@@ -230,7 +242,7 @@ export class LLMClient {
     }
 
     try {
-      while (true) {
+      streamLoop: while (true) {
         if (signal?.aborted) break;
 
         const { done, value } = await reader.read();
@@ -252,7 +264,7 @@ export class LLMClient {
           const data = trimmed.slice(6);
 
           if (data === '[DONE]') {
-            return;
+            break streamLoop;
           }
 
           let parsed: SSEPayload;
@@ -260,6 +272,16 @@ export class LLMClient {
             parsed = JSON.parse(data) as SSEPayload;
           } catch {
             continue;
+          }
+
+          // Capture usage from any chunk — when stream_options.include_usage is set
+          // it usually arrives on its own chunk with choices=[].
+          if (parsed.usage) {
+            pendingUsage = {
+              inputTokens: parsed.usage.prompt_tokens,
+              outputTokens: parsed.usage.completion_tokens,
+              totalTokens: parsed.usage.total_tokens,
+            };
           }
 
           const choice = parsed.choices?.[0];
@@ -296,23 +318,18 @@ export class LLMClient {
             }
           }
 
-          // Done
           if (choice.finish_reason) {
-            // Emit accumulated tool calls
-            for (const tc of toolCalls.values()) {
-              yield { type: 'tool_call', id: tc.id, name: tc.name, arguments: tc.arguments };
-            }
-
-            const usage: TokenUsage | undefined = parsed.usage ? {
-              inputTokens: parsed.usage.prompt_tokens,
-              outputTokens: parsed.usage.completion_tokens,
-              totalTokens: parsed.usage.total_tokens,
-            } : undefined;
-
-            yield { type: 'done', finishReason: choice.finish_reason, usage };
-            return;
+            pendingFinishReason = choice.finish_reason;
+            donePending = true;
           }
         }
+      }
+
+      if (donePending) {
+        for (const tc of toolCalls.values()) {
+          yield { type: 'tool_call', id: tc.id, name: tc.name, arguments: tc.arguments };
+        }
+        yield { type: 'done', finishReason: pendingFinishReason ?? 'stop', usage: pendingUsage };
       }
     } finally {
       if (signal) signal.removeEventListener('abort', abortHandler);

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -200,6 +200,60 @@ describe('LLMClient', () => {
       expect(chunks).toHaveLength(1);
       expect(chunks[0]).toEqual({ type: 'content', data: 'Hi' });
     });
+
+    it('captures usage from a separate chunk that arrives after finish_reason', async () => {
+      // Real OpenAI / OpenRouter / LiteLLM behaviour with stream_options.include_usage=true:
+      // the usage payload arrives in its own chunk (with empty choices) AFTER the chunk
+      // that carried finish_reason. Previously the parser emitted `done` on finish_reason
+      // and returned, dropping the usage chunk → all production traces had usage=0.
+      const sseResponse = createSSEResponse([
+        'data: {"choices":[{"delta":{"content":"hi"},"index":0}]}',
+        'data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"total_tokens":49}}',
+        'data: [DONE]',
+      ]);
+      const fetchSpy = mockFetch(sseResponse);
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of client.streamChat({ messages: [{ role: 'user', content: 'Hi' }] })) {
+        chunks.push(chunk);
+      }
+
+      const done = chunks.find((c) => c.type === 'done');
+      expect(done).toMatchObject({
+        type: 'done',
+        finishReason: 'stop',
+        usage: { inputTokens: 42, outputTokens: 7, totalTokens: 49 },
+      });
+
+      // And the streamChat body must opt-in to receiving usage.
+      const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+      expect(body.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('emits a single done event even when finish_reason and usage share a chunk', async () => {
+      // Backwards-compat: some providers still bundle usage into the finish_reason
+      // chunk (this is what the older test assumed). The new buffering parser must
+      // still emit exactly one `done` for that legacy shape.
+      const sseResponse = createSSEResponse([
+        'data: {"choices":[{"delta":{"content":"ok"},"index":0}]}',
+        'data: {"choices":[{"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}',
+        'data: [DONE]',
+      ]);
+      mockFetch(sseResponse);
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of client.streamChat({ messages: [{ role: 'user', content: 'Hi' }] })) {
+        chunks.push(chunk);
+      }
+
+      const doneChunks = chunks.filter((c) => c.type === 'done');
+      expect(doneChunks).toHaveLength(1);
+      expect(doneChunks[0]).toMatchObject({
+        finishReason: 'stop',
+        usage: { inputTokens: 3, outputTokens: 1, totalTokens: 4 },
+      });
+    });
   });
 
   describe('embed()', () => {


### PR DESCRIPTION
Bug: todas as execuções via streamChat() retornavam usage=0/0/0, quebrando cost tracking, telemetria e CostPolicy. Confirmado em produção (Langfuse trace metadata.usage = {promptTokens:0,...} mesmo em respostas com tokens reais).

Causas, ambas em llm-client.ts:

1. body do POST /chat/completions não inclui stream_options. OpenAI-compatíveis (OpenAI, OpenRouter, LiteLLM, vLLM) só emitem usage no SSE quando { stream_options: { include_usage: true } } é passado. Sem isso, nenhum chunk traz usage.

2. parseSSEStream emitia o evento 'done' assim que via finish_reason e chamava `return`. Quando include_usage está ligado, OpenAI manda o usage num chunk SEPARADO (com choices=[]) APÓS o chunk com finish_reason. O parser fechava antes desse chunk chegar — e ainda tinha `if (!choice) continue` que descartaria o chunk de qualquer jeito.

Fix:

- streamChat: adiciona stream_options.include_usage = true no body.
- parseSSEStream: passa a bufferizar usage e finish_reason até o fim do stream ([DONE] ou EOF do reader), e só então emite tool_calls + done. Captura usage de qualquer chunk que tenha o campo, com ou sem choices preenchidos.

Backwards-compat: provedores que ainda mandam usage no mesmo chunk do finish_reason continuam funcionando (caso testado).

Testes:
- Novo: usage em chunk separado depois do finish_reason → done com usage preenchido + verifica stream_options no body.
- Novo: usage embutido no chunk do finish_reason (legado) → done único com usage.
- Existentes: 19/19 verdes.