### PR TITLE
fix: bloqueia path traversal em readMemory/deleteMemory (closes #86)

### DIFF
--- a/src/memory/file-memory-system.ts
+++ b/src/memory/file-memory-system.ts
@@ -29,7 +29,7 @@ import {
   MAX_ENTRYPOINT_BYTES,
   parseMemoryType,
 } from './memory-types.js';
-import { resolveMemoryDir, ensureMemoryDir, sanitizeFilename, sanitizeFrontmatterValue, validateThreadId } from './memory-paths.js';
+import { resolveMemoryDir, ensureMemoryDir, sanitizeFilename, sanitizeFrontmatterValue, validateThreadId, validateMemoryPath } from './memory-paths.js';
 import { scanMemoryFiles, formatMemoryManifest, parseFrontmatter } from './memory-scanner.js';
 import { selectRelevantMemories } from './memory-relevance.js';
 import { memoryFreshnessNote } from './memory-age.js';
@@ -123,7 +123,9 @@ export class FileMemorySystem {
   async readMemory(filename: string, threadId?: string): Promise<MemoryFile | null> {
     try {
       const dir = this.resolveDir(threadId);
-      const filePath = join(dir, filename);
+      const candidate = join(dir, filename);
+      const filePath = validateMemoryPath(candidate, this.memoryDir);
+      if (!filePath) return null;
       const content = await readFile(filePath, 'utf-8');
       const fileStat = await stat(filePath);
       const frontmatter = parseFrontmatter(content);
@@ -152,7 +154,9 @@ export class FileMemorySystem {
   async deleteMemory(filename: string, threadId?: string): Promise<boolean> {
     try {
       const dir = this.resolveDir(threadId);
-      const filePath = join(dir, filename);
+      const candidate = join(dir, filename);
+      const filePath = validateMemoryPath(candidate, this.memoryDir);
+      if (!filePath) return false;
       await unlink(filePath);
       await this.removeFromIndex(filename, threadId);
       this.logger.debug('Memory deleted', { filename, threadId: threadId ?? 'global' });

--- a/tests/unit/memory/file-memory-system.test.ts
+++ b/tests/unit/memory/file-memory-system.test.ts
@@ -368,3 +368,58 @@ describe('FileMemorySystem — concurrent writes (withWriteLock)', () => {
     }
   });
 });
+
+describe('FileMemorySystem — path traversal in readMemory/deleteMemory (#86)', () => {
+  let tempDir: string;
+  let system: FileMemorySystem;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'fms-pt-'));
+    const client = createMockClient();
+    const logger = createMockLogger();
+    system = new FileMemorySystem({ memoryDir: tempDir }, client, logger);
+    await system.ensureDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('readMemory — rejects path traversal via ../', async () => {
+    const result = await system.readMemory('../../etc/passwd');
+    expect(result).toBeNull();
+  });
+
+  it('readMemory — rejects null byte in filename', async () => {
+    const result = await system.readMemory('valid\x00../../etc/shadow');
+    expect(result).toBeNull();
+  });
+
+  it('readMemory — rejects URL-encoded traversal', async () => {
+    const result = await system.readMemory('%2e%2e%2fetc%2fpasswd');
+    expect(result).toBeNull();
+  });
+
+  it('readMemory — still reads a valid file within the memory dir', async () => {
+    await system.saveMemory({ name: 'safe', description: 'ok', type: 'user', content: 'body' });
+    const result = await system.readMemory('safe.md');
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('body');
+  });
+
+  it('deleteMemory — rejects path traversal via ../', async () => {
+    const result = await system.deleteMemory('../../important.txt');
+    expect(result).toBe(false);
+  });
+
+  it('deleteMemory — rejects null byte in filename', async () => {
+    const result = await system.deleteMemory('valid\x00../../tmp/evil');
+    expect(result).toBe(false);
+  });
+
+  it('deleteMemory — still deletes a valid file within the memory dir', async () => {
+    await system.saveMemory({ name: 'todelete', description: 'ok', type: 'user', content: 'c' });
+    const deleted = await system.deleteMemory('todelete.md');
+    expect(deleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Issue
Closes #86

## Problema
`readMemory()` e `deleteMemory()` em `FileMemorySystem` concatenavam `join(dir, filename)` sem validar o parâmetro `filename`, permitindo path traversal como `../../etc/passwd`. A função `validateMemoryPath()` já existia em `memory-paths.ts` e era usada em `memory-tools.ts`, mas não era chamada nos métodos públicos da classe.

## Abordagem TDD
- Teste em: `tests/unit/memory/file-memory-system.test.ts` (describe `path traversal in readMemory/deleteMemory (#86)`)
- Falha antes do fix (red): `readMemory('../../etc/passwd')` retornava o conteúdo real de `/etc/passwd`
- Implementação mínima em: `src/memory/file-memory-system.ts` — adicionado `validateMemoryPath()` no início de `readMemory()` e `deleteMemory()`; import adicionado
- Suíte completa: 821 testes passando (1 arquivo pré-existente com falha no `examples/teams-bot`)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wutFDshShFAWJu1GNtC8r)_