### PR TITLE
fix: allowedCommands:[] bloqueia todos os comandos — deny-by-default (closes #87)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -54,7 +54,10 @@ export function createBashTool(options: BashToolOptions = {}): AgentTool {
     async execute(rawArgs: unknown, signal: AbortSignal) {
       const { command, timeout } = BashParams.parse(rawArgs);
 
-      if (allowedCommands && allowedCommands.length > 0) {
+      if (allowedCommands !== undefined) {
+        if (allowedCommands.length === 0) {
+          return { content: 'No commands are permitted (empty allowedCommands)', isError: true };
+        }
         // Reject shell metacharacters that allow command chaining/injection even when the
         // first token is in the allow-list (e.g. "ls; rm -rf /", "echo hi | cat").
         const DANGEROUS_METACHAR = /[;&|`$<>()\n\\]/;

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -132,6 +132,30 @@ describe('builtin/bash', () => {
     });
   });
 
+  describe('empty allowedCommands blocks all commands (#87)', () => {
+    it('blocks any command when allowedCommands is empty array', async () => {
+      const tool = createBashTool({ allowedCommands: [] });
+      const result = await tool.execute({ command: 'echo hello' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/no commands|empty allowedCommands|not permitted/i);
+    });
+
+    it('blocks destructive commands when allowedCommands is empty array', async () => {
+      const tool = createBashTool({ allowedCommands: [] });
+      const result = await tool.execute({ command: 'rm -rf /' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('still allows all commands when allowedCommands is undefined', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo unrestricted' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('unrestricted');
+    });
+  });
+
   describe('timeout parameter bounds (issue #9)', () => {
     it('should reject timeout=0 (would disable exec timeout)', async () => {
       const tool = createBashTool();


### PR DESCRIPTION
## Issue
Closes #87

## Problema
`createBashTool({ allowedCommands: [] })` deveria bloquear todos os comandos (deny-by-default), mas a condição `allowedCommands.length > 0` ignorava silenciosamente o array vazio, permitindo execução irrestrita. Consumidores que passam `[]` esperando um sandbox bloqueado ficavam com uma falsa sensação de segurança.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/bash.test.ts` (describe `empty allowedCommands blocks all commands (#87)`)
- Falha antes do fix (red): `createBashTool({ allowedCommands: [] }).execute({ command: 'echo hello' })` retornava `isError: false`
- Implementação mínima em: `src/tools/builtin/bash.ts:57` — mudança de `allowedCommands.length > 0` para `allowedCommands !== undefined`, com retorno imediato de erro quando `length === 0`
- Suíte completa: 817 testes passando

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wutFDshShFAWJu1GNtC8r)_