### PR TITLE
fix: MAX_POOL_SIZE=500 com evicção LRU no agent pool do teams-bot (closes #88)

### DIFF
--- a/examples/teams-bot/src/agent-factory.ts
+++ b/examples/teams-bot/src/agent-factory.ts
@@ -32,6 +32,9 @@ const CLEANUP_INTERVAL = 5 * 60_000;
 /** Destroy agents idle for more than 30 minutes. */
 const IDLE_TTL = 30 * 60_000;
 
+/** Maximum number of concurrent agents — prevents OOM under DoS. */
+export let MAX_POOL_SIZE = 500;
+
 const SYSTEM_PROMPT = `You are Albert, a helpful Microsoft Teams assistant for managing businesses on the Albert platform.
 
 You have PERSISTENT MEMORY across conversations. You remember facts, preferences, and context from previous messages. Never say you don't have memory or don't remember previous conversations — you do.
@@ -69,16 +72,24 @@ Formatting:
  * Creates one on first access; subsequent calls return the cached instance.
  */
 export async function getAgent(conversationId: string): Promise<Agent> {
-  // Return existing agent
+  // Return existing agent — move to end to maintain LRU order
   const entry = pool.get(conversationId);
   if (entry) {
     entry.lastUsedAt = Date.now();
+    pool.delete(conversationId);
+    pool.set(conversationId, entry);
     return entry.agent;
   }
 
   // Deduplicate concurrent init for the same conversation
   if (initializing.has(conversationId)) {
     return initializing.get(conversationId)!;
+  }
+
+  // LRU eviction: Map preserves insertion order; first entry is least-recently-used
+  if (pool.size >= MAX_POOL_SIZE) {
+    const oldestId = pool.keys().next().value;
+    if (oldestId) await destroyAgent(oldestId);
   }
 
   const promise = createAgent(conversationId);
@@ -229,14 +240,15 @@ export async function validateMCP(): Promise<{ status: 'enabled' | 'disabled'; r
 }
 
 /** Pool stats for monitoring. */
-export function getPoolStats(): { size: number; conversationIds: string[] } {
-  return { size: pool.size, conversationIds: [...pool.keys()] };
+export function getPoolStats(): { size: number; maxSize: number; conversationIds: string[] } {
+  return { size: pool.size, maxSize: MAX_POOL_SIZE, conversationIds: [...pool.keys()] };
 }
 
-/** @internal — test-only: clear pool state between tests. */
-export function _resetPool(): void {
+/** @internal — test-only: clear pool state and optionally override MAX_POOL_SIZE. */
+export function _resetPool(maxPoolSize = 500): void {
   pool.clear();
   initializing.clear();
+  MAX_POOL_SIZE = maxPoolSize;
 }
 
 // --- Periodic cleanup of idle agents ---

--- a/tests/unit/examples/teams-bot/agent-factory.test.ts
+++ b/tests/unit/examples/teams-bot/agent-factory.test.ts
@@ -65,9 +65,61 @@ import {
   _resetPool,
 } from '../../../../examples/teams-bot/src/agent-factory.js';
 
+// Ensure this exists after fix
+const { MAX_POOL_SIZE } = await import('../../../../examples/teams-bot/src/agent-factory.js');
+
 describe('Agent Pool (agent-factory)', () => {
   beforeEach(() => {
     _resetPool();
+  });
+
+  describe('pool size limit (#88)', () => {
+    beforeEach(() => {
+      _resetPool(3); // use small limit for testing
+    });
+
+    it('exports MAX_POOL_SIZE', () => {
+      expect(typeof MAX_POOL_SIZE).toBe('number');
+      expect(MAX_POOL_SIZE).toBeGreaterThan(0);
+    });
+
+    it('getPoolStats includes maxSize', async () => {
+      _resetPool(3);
+      const stats = getPoolStats();
+      expect(stats).toHaveProperty('maxSize');
+      expect(stats.maxSize).toBe(3);
+    });
+
+    it('evicts oldest agent when pool is at capacity', async () => {
+      _resetPool(3);
+      await getAgent('conv-a');
+      await getAgent('conv-b');
+      await getAgent('conv-c');
+      expect(getPoolStats().size).toBe(3);
+
+      // Adding a 4th should evict the oldest (conv-a)
+      await getAgent('conv-d');
+      const stats = getPoolStats();
+      expect(stats.size).toBe(3);
+      expect(stats.conversationIds).not.toContain('conv-a');
+      expect(stats.conversationIds).toContain('conv-d');
+    });
+
+    it('evicts by lastUsedAt (LRU) — most recently used survives', async () => {
+      _resetPool(2);
+      await getAgent('conv-old');
+      await getAgent('conv-new');
+      // Access conv-old to make it more recently used
+      await getAgent('conv-old');
+
+      // Adding a 3rd — conv-new is now the oldest (LRU)
+      await getAgent('conv-third');
+      const stats = getPoolStats();
+      expect(stats.size).toBe(2);
+      expect(stats.conversationIds).not.toContain('conv-new');
+      expect(stats.conversationIds).toContain('conv-old');
+      expect(stats.conversationIds).toContain('conv-third');
+    });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Issue
Closes #88

## Problema
O pool de agentes em `examples/teams-bot/src/agent-factory.ts` era um `Map` ilimitado. Com requisições de múltiplos `conversationId` únicos (DoS ou alta concorrência), cada nova conversa criava um agente novo com SQLite, LLMClient e conexão MCP SSE, levando a exaustão de memória e file descriptors.

## Abordagem TDD
- Teste em: `tests/unit/examples/teams-bot/agent-factory.test.ts` (describe `pool size limit (#88)`)
- Falha antes do fix (red): pool crescia além de `MAX_POOL_SIZE` sem evicção
- Implementação mínima em: `examples/teams-bot/src/agent-factory.ts`
  - `export let MAX_POOL_SIZE = 500`
  - LRU eviction em `getAgent()` usando ordem de inserção do Map (agente mais antigo no início)
  - Move para o fim do Map ao acessar (manter LRU ordering correto)
  - `getPoolStats()` expõe `maxSize`
  - `_resetPool(maxPoolSize)` permite configurar limite em testes
- Suíte completa: 826 testes passando

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wutFDshShFAWJu1GNtC8r)_