### PR TITLE
fix: sanitizeForLog previne log injection via conversationId no teams-bot (closes #91)

### DIFF
--- a/examples/teams-bot/src/agent-factory.ts
+++ b/examples/teams-bot/src/agent-factory.ts
@@ -17,6 +17,13 @@ const pgPool = config.database.url
   ? new pg.Pool({ connectionString: config.database.url, max: 10 })
   : null;
 
+/** Sanitize a string for safe embedding in log messages — strips control chars and ANSI escapes. */
+function sanitizeForLog(value: string, maxLen = 40): string {
+  return value
+    .replace(/[\x00-\x1f\x7f]/g, '_')
+    .slice(0, maxLen);
+}
+
 /** One agent per conversation — full isolation of state, tools, and memory. */
 const pool = new Map<string, PoolEntry>();
 
@@ -150,9 +157,9 @@ async function createAgent(conversationId: string): Promise<Agent> {
       });
       const health = agent.getHealth();
       const mcpTools = health.servers.find(s => s.name === 'albert')?.toolCount ?? 0;
-      console.log(`[${conversationId}] MCP albert connected — ${mcpTools} tools loaded`);
+      console.log(`[${sanitizeForLog(conversationId)}] MCP albert connected — ${mcpTools} tools loaded`);
     } catch (error) {
-      console.error(`[${conversationId}] ⚠️  MCP albert FAILED — tools will NOT be available:`, error instanceof Error ? error.message : error);
+      console.error(`[${sanitizeForLog(conversationId)}] ⚠️  MCP albert FAILED — tools will NOT be available:`, error instanceof Error ? error.message : error);
     }
   }
 
@@ -161,7 +168,7 @@ async function createAgent(conversationId: string): Promise<Agent> {
   agent.addSkill(onboardingSkill);
   agent.addSkill(blogContentSkill);
 
-  console.log(`[pool] Agent created for conversation ${conversationId.slice(0, 20)}... (pool size: ${pool.size + 1})`);
+  console.log(`[pool] Agent created for conversation ${sanitizeForLog(conversationId, 20)}... (pool size: ${pool.size + 1})`);
   return agent;
 }
 
@@ -173,7 +180,7 @@ export async function destroyAgent(conversationId: string): Promise<void> {
   if (entry) {
     pool.delete(conversationId);
     await entry.agent.destroy();
-    console.log(`[pool] Agent destroyed for conversation ${conversationId.slice(0, 20)}...`);
+    console.log(`[pool] Agent destroyed for conversation ${sanitizeForLog(conversationId, 20)}...`);
   }
 }
 
@@ -184,7 +191,7 @@ export async function destroyAll(): Promise<void> {
   const entries = [...pool.entries()];
   pool.clear();
   await Promise.allSettled(entries.map(([id, e]) => {
-    console.log(`[pool] Destroying agent ${id.slice(0, 20)}...`);
+    console.log(`[pool] Destroying agent ${sanitizeForLog(id, 20)}...`);
     return e.agent.destroy();
   }));
 }
@@ -252,7 +259,7 @@ setInterval(async () => {
 
   for (const id of toRemove) {
     await destroyAgent(id);
-    console.log(`[pool] Evicted idle agent ${id.slice(0, 20)}...`);
+    console.log(`[pool] Evicted idle agent ${sanitizeForLog(id, 20)}...`);
   }
 
   if (toRemove.length > 0) {

--- a/tests/unit/examples/teams-bot/agent-factory.test.ts
+++ b/tests/unit/examples/teams-bot/agent-factory.test.ts
@@ -150,4 +150,33 @@ describe('Agent Pool (agent-factory)', () => {
     const second = await getAgent('conv-1');
     expect(second).not.toBe(first);
   });
+
+  describe('log injection prevention (#91)', () => {
+    it('sanitizes newline in conversationId before logging', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const maliciousId = 'conv-1\n[FAKE] Admin password: admin123';
+      await getAgent(maliciousId);
+      const allLogs = logSpy.mock.calls.flat().join('\n');
+      expect(allLogs).not.toMatch(/\n\[FAKE\]/);
+      logSpy.mockRestore();
+    });
+
+    it('sanitizes ANSI escape sequences in conversationId before logging', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const maliciousId = 'conv-2\x1b[31mRED_TEXT\x1b[0m';
+      await getAgent(maliciousId);
+      const allLogs = logSpy.mock.calls.flat().join('');
+      expect(allLogs).not.toContain('\x1b[31m');
+      logSpy.mockRestore();
+    });
+
+    it('sanitizes carriage return in conversationId before logging', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const maliciousId = 'conv-3\r[INJECTED]';
+      await getAgent(maliciousId);
+      const allLogs = logSpy.mock.calls.flat().join('');
+      expect(allLogs).not.toContain('\r');
+      logSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #91

## Problema
O `conversationId` recebido do Microsoft Teams era interpolado diretamente em `console.log`/`console.error` sem sanitização. Um ID malicioso como `19:legit@thread\n[2026-05-05] Admin password: admin123` injeta linhas falsas nos logs, podendo confundir sistemas de SIEM/SIEM e falsificar entradas de auditoria (CWE-117).

## Abordagem TDD
- Teste em: `tests/unit/examples/teams-bot/agent-factory.test.ts` (describe `log injection prevention (#91)`)
- Falha antes do fix (red): `getAgent('conv-1\n[FAKE] Admin password')` produzia `\n[FAKE]` nos logs
- Implementação mínima em: `examples/teams-bot/src/agent-factory.ts`
  - Função `sanitizeForLog(value, maxLen=40)` que remove `[\x00-\x1f\x7f]` (inclui `\n`, `\r`, `\x1b`) e corta em `maxLen`
  - Aplicada em todos os `console.log`/`console.error` que usam `conversationId` ou `id` (6 locais)
- Suíte completa: 825 testes passando

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wutFDshShFAWJu1GNtC8r)_