### PR TITLE
fix(security): semgrep findings — shell injection risk e Math.random …

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,4 +50,6 @@ jobs:
 
       - name: Validate commits
         if: github.event_name == 'pull_request'
-        run: pnpm commitlint --from origin/${{ github.base_ref }} --to HEAD
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: pnpm commitlint --from "origin/$BASE_REF" --to HEAD

--- a/tests/unit/knowledge/sqlite-vector-store.test.ts
+++ b/tests/unit/knowledge/sqlite-vector-store.test.ts
@@ -56,7 +56,8 @@ describe('SQLiteVectorStore', () => {
       store.upsert(
         createChunk({
           id: `c${i}`,
-          embedding: new Float32Array([Math.random(), Math.random(), 0, 0]),
+          // Deterministic distinct embeddings — values don't matter, only that there are 10.
+          embedding: new Float32Array([i / 10, ((i * 7) % 10) / 10, 0, 0]),
         }),
       );
     }


### PR DESCRIPTION
…em test

1. pr-check.yml: github.base_ref interpolado direto no run: step e risco
   de shell injection. Move pra env: var BASE_REF, expande via "$BASE_REF"
   (quotado). Rule: yaml.github-actions.security.run-shell-injection.

2. sqlite-vector-store.test.ts: Math.random() pra gerar embeddings do test topK. Substitui por valores deterministicos (i/10 e (i*7)%10/10) — alem de calar o lint, torna o test reproduzivel. Rule: ajinabraham.njsscan.crypto.crypto_node.node_insecure_random_generator.