### PR TITLE
chore(security): CodeQL + gitleaks + pin actions a SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Segunda 06:00 UTC — pega CVEs novas em codigo ja mergeado
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,15 +17,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
           version: 10
 
@@ -57,17 +57,17 @@ jobs:
       id-token: write # Required for npm provenance attestation
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
           version: 10
 

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,31 @@
+name: Secrets Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Segunda 06:00 UTC — pega secrets vazadas em commits ja mergeados
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE so eh necessario pra repo de organizacao;
+          # repo pessoal/publico roda free.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Semgrep
         run: |


### PR DESCRIPTION
## Sumário

Defesa em profundidade no pipeline de segurança:

### 1. **gitleaks** — `secrets.yml`
Detector dedicado de secrets vazadas (API keys, tokens, certificados privados, etc) em commits. Semgrep cobre algumas regras de secrets mas o gitleaks é o gold standard pra isso. Roda em PR + push em main + cron semanal.

### 2. **CodeQL** — `codeql.yml`
SAST nativo do GitHub, complementa o Semgrep com regras diferentes. Queries `security-extended` (mais ampla que o default). Achados aparecem na aba Security do GitHub. Free pra OSS.

### 3. **Pin de actions a SHA** — todos os workflows
Tags móveis (`@v6`) podem ser hijacked se a conta da action for comprometida → atacante reescreve o tag → seu CI roda código malicioso com acesso aos secrets. SHA fixo elimina esse vetor.

| Action | SHA | Comment |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6 |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6 |
| `pnpm/action-setup` | `8912a9102ac27614460f54aedde9e1e7f9aec20d` | v6 |
| `gitleaks/gitleaks-action` | `ff98106e4c7b2bc287b24eaf42907196329070c7` | v2 |
| `github/codeql-action/{init,analyze}` | `0daab03d71ff584ef619d027a3fd9146679c5d84` | v3 |

Dependabot atualiza esses SHAs via PR (já configurado no `.github/dependabot.yml`).

## Verificação

- [x] YAMLs validados (`python3 -c yaml.safe_load`)
- [x] CI: `pr-check` + Semgrep + CodeQL + gitleaks rodando neste PR
- [x] Após merge: workflows novos passam a rodar em todo PR + cron semanal

## Score esperado

De ~75 → ~85 conforme o plano discutido (gitleaks +3, CodeQL +3, pin SHA +3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)