### PR TITLE
fix: substitui git reset --hard por merge --ff-only em release.yml (closes #89)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,11 @@ jobs:
 
           # Sync with the latest main before bumping so we never start from a
           # stale SHA when multiple PRs are merged in quick succession.
+          # --ff-only fails loudly if a concurrent commit cannot be fast-forwarded,
+          # preventing silent loss of commits (issue #89).
           git fetch origin main
           git checkout main
-          git reset --hard origin/main
+          git merge --ff-only origin/main
 
           NEW_VERSION=$(npm version ${{ steps.bump.outputs.type }} --no-git-tag-version)
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"

--- a/tests/unit/package-security.test.ts
+++ b/tests/unit/package-security.test.ts
@@ -36,6 +36,20 @@ describe('package.json security overrides (issue #26)', () => {
   });
 });
 
+describe('release.yml safe sync — no destructive reset (issue #89)', () => {
+  it('does NOT use git reset --hard in the bump/version step', () => {
+    // git reset --hard silently discards any commits that landed between fetch and reset,
+    // making concurrent-push races invisible. A fast-forward merge fails loudly instead.
+    expect(releaseYml).not.toMatch(/git\s+reset\s+--hard/);
+  });
+
+  it('uses git merge --ff-only to sync with remote main before bumping', () => {
+    // --ff-only aborts if the local HEAD cannot be fast-forwarded, surfacing races as errors
+    // rather than silently overwriting them.
+    expect(releaseYml).toMatch(/git\s+merge\s+--ff-only\s+origin\/main/);
+  });
+});
+
 describe('release.yml shell injection hardening (issue #51)', () => {
   it('does NOT interpolate ${{ steps.version.outputs.version }} directly in a run: shell command', () => {
     // Direct interpolation: VERSION=${{ steps.version.outputs.version }} inside run: is a shell injection risk.


### PR DESCRIPTION
## Issue
Closes #89

## Problema
O job `publish` do workflow `release.yml` executava `git reset --hard origin/main` antes do bump de versão. Se dois PRs fossem mergeados em rápida sucessão e um commit chegasse ao `main` entre o `git fetch` e o `reset`, esse commit seria descartado silenciosamente — sem erro, sem log. Isso tornava o pipeline de release opaco a corridas de commit e potencialmente publicava versões com código incompleto.

## Abordagem TDD

- **Teste em:** `tests/unit/package-security.test.ts` — `describe('release.yml safe sync — no destructive reset (issue #89)')`
- **Falha antes do fix (red):** 2 testes falhando — o workflow continha `git reset --hard` e não continha `git merge --ff-only origin/main`
- **Implementação mínima em:** `.github/workflows/release.yml` — substituição de `git reset --hard origin/main` por `git merge --ff-only origin/main`
- **Suíte completa:** 832 testes passam; a única falha de arquivo (`agent-factory.test.ts`) é pré-existente em `main` (falha de resolução de pacote não buildado, não relacionada a esta mudança)

## Por que `--ff-only` é mais seguro

| | `git reset --hard origin/main` | `git merge --ff-only origin/main` |
|---|---|---|
| Commit concorrente chega após o fetch | Descartado silenciosamente | Merge **aborta com erro explícito** |
| Visibilidade da falha | Nenhuma | Job falha com mensagem clara |
| Estado do repositório | Pode perder commits | Nunca avança se não for fast-forward |

## Escopo
Esta PR aborda o item 4 da issue (#89): remoção do `git reset --hard`. Os demais pontos (uso de `release-please`, branch protection rules, versioning por commit messages) envolvem decisões de produto/arquitetura e não foram incluídos.

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste escrito antes do fix (RED confirmado: 2 falhas)
- [x] Fix mínimo aplicado (GREEN: 2 testes passam)
- [x] Suíte completa: 832 testes verdes
- [x] Sem mudança de regras existentes
- [x] Sem refactors oportunistas

https://claude.ai/code/session_01Lmwup1qMHtkhSgNh2QgZhM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lmwup1qMHtkhSgNh2QgZhM)_