### PR TITLE
fix: SSRF guard em LLMClient.baseUrl bloqueia IPs privados (closes #113)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -8,6 +8,7 @@ import type {
 import type { TokenUsage } from '../contracts/entities/token-usage.js';
 import { retry } from '../utils/retry.js';
 import { buildReasoningArgs, isReasoningModel, requiresNoSystemRole } from './reasoning.js';
+import { validateSsrfUrl } from '../utils/ssrf-guard.js';
 
 export interface LLMClientConfig {
   apiKey: string;
@@ -55,7 +56,10 @@ export class LLMClient {
   constructor(config: LLMClientConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model;
-    this.baseUrl = (config.baseUrl ?? 'https://openrouter.ai/api/v1').replace(/\/$/, '');
+    const rawBase = (config.baseUrl ?? 'https://openrouter.ai/api/v1').replace(/\/$/, '');
+    const ssrfError = validateSsrfUrl(rawBase);
+    if (ssrfError) throw new Error(`baseUrl bloqueada (SSRF): ${ssrfError}`);
+    this.baseUrl = rawBase;
     this.timeoutMs = config.timeoutMs ?? LLMClient.DEFAULT_TIMEOUT_MS;
   }
 

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -466,6 +466,73 @@ describe('LLMClient', () => {
     });
   });
 
+  describe('SSRF protection (issue #113)', () => {
+    it('throws when baseUrl points to cloud metadata endpoint (169.254.169.254)', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+            baseUrl: 'http://169.254.169.254/api/v1',
+          }),
+      ).toThrow(/baseUrl bloqueada \(SSRF\)/);
+    });
+
+    it('throws when baseUrl points to private range 10.x.x.x', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+            baseUrl: 'http://10.0.0.1/api/v1',
+          }),
+      ).toThrow(/baseUrl bloqueada \(SSRF\)/);
+    });
+
+    it('throws when baseUrl points to private range 192.168.x.x', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+            baseUrl: 'http://192.168.1.100/v1',
+          }),
+      ).toThrow(/baseUrl bloqueada \(SSRF\)/);
+    });
+
+    it('throws when baseUrl points to localhost', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+            baseUrl: 'http://localhost/api/v1',
+          }),
+      ).toThrow(/baseUrl bloqueada \(SSRF\)/);
+    });
+
+    it('accepts a public HTTPS baseUrl without throwing', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+            baseUrl: 'https://openrouter.ai/api/v1',
+          }),
+      ).not.toThrow();
+    });
+
+    it('uses default baseUrl (openrouter.ai) when none provided — no SSRF error', () => {
+      expect(
+        () =>
+          new LLMClient({
+            apiKey: 'test-key',
+            model: 'test/model',
+          }),
+      ).not.toThrow();
+    });
+  });
+
   describe('reasoning', () => {
     it('should convert system messages for o1 models', async () => {
       const o1Client = new LLMClient({


### PR DESCRIPTION
## Issue
Closes #113

## Problema
O `LLMClient` aceitava qualquer URL em `baseUrl` e injetava a API key via `Authorization: Bearer` em todas as requisições, sem validar SSRF. Um atacante que controlasse a config podia apontar para `http://169.254.169.254` (metadata de cloud) e exfiltrar a chave de API.

## Abordagem TDD
- Teste em: `tests/unit/llm/llm-client.test.ts` (describe `SSRF protection (issue #113)`)
- Falha antes do fix (red): constructor não lançava erro para IPs privados/link-local
- Implementação mínima em: `src/llm/llm-client.ts` — importa `validateSsrfUrl` e chama no constructor após calcular `rawBase`
- Suíte completa: 838 testes verdes (1 falha pré-existente em teams-bot não relacionada)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJmm5d3HzCKEqiFY1yLGJ1)_