### PR TITLE
fix: memory_write resolve symlinks via safeJoinResolved (closes #114)

### DIFF
--- a/src/memory/memory-tools.ts
+++ b/src/memory/memory-tools.ts
@@ -18,7 +18,6 @@ import { scanMemoryFiles, formatMemoryManifest, parseFrontmatter } from './memor
 import {
   sanitizeFilename,
   sanitizeFrontmatterValue,
-  validateMemoryPath,
   validateMemoryPathResolved,
   validateThreadId,
 } from './memory-paths.js';
@@ -81,13 +80,7 @@ function validateFilename(filename: string): string | null {
 export function createMemoryTools(memoryDir: string, threadId?: string): AgentTool[] {
   const dir = resolveDir(memoryDir, threadId);
 
-  /** Defense-in-depth: ensure the resolved path stays inside memoryDir (sync, shallow). */
-  const safeJoin = (filename: string): string | null => {
-    const candidate = join(dir, filename);
-    return validateMemoryPath(candidate, memoryDir) ?? null;
-  };
-
-  /** Like safeJoin, but resolves symlinks via realpath to prevent symlink escape. */
+  /** Resolves symlinks via realpath to prevent symlink escape. */
   const safeJoinResolved = async (filename: string): Promise<string | null> => {
     const candidate = join(dir, filename);
     return (await validateMemoryPathResolved(candidate, memoryDir)) ?? null;
@@ -163,7 +156,7 @@ export function createMemoryTools(memoryDir: string, threadId?: string): AgentTo
       const filename = sanitizeFilename(args.name);
 
       await mkdir(dir, { recursive: true });
-      const safePath = safeJoin(filename);
+      const safePath = await safeJoinResolved(filename);
       if (!safePath) return { content: 'Invalid path', isError: true };
 
       const fileContent = [

--- a/tests/unit/memory/memory-tools.test.ts
+++ b/tests/unit/memory/memory-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, readFile, writeFile, rm, mkdir } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, rm, mkdir, symlink, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createMemoryTools } from '../../../src/memory/memory-tools.js';
@@ -243,6 +243,57 @@ describe('memory-tools', () => {
       const result = await tool.execute({ filename: 'file\rEVIL.md' }, signal);
       const res = typeof result === 'string' ? { content: result, isError: false } : result;
       expect(res.isError).toBe(true);
+    });
+  });
+
+  describe('memory_write symlink traversal (issue #114)', () => {
+    it('rejects write when target filename is a symlink pointing outside memoryDir', async () => {
+      // Create a separate "outside" directory to be the symlink target
+      const outsideDir = await mkdtemp(join(tmpdir(), 'memtools-outside-'));
+      const outsideFile = join(outsideDir, 'secret.txt');
+      await writeFile(outsideFile, 'original-secret', 'utf-8');
+
+      // Place a symlink inside memoryDir with the name memory_write would generate
+      // for name="User Role" → sanitizeFilename → "user-role.md"
+      const symlinkPath = join(tempDir, 'user-role.md');
+      await symlink(outsideFile, symlinkPath);
+
+      const tool = findTool(tools, 'memory_write');
+      const result = await tool.execute(
+        {
+          name: 'User Role',
+          description: 'Attacker-controlled desc',
+          type: 'user',
+          content: 'MALICIOUS PAYLOAD',
+        },
+        signal,
+      );
+
+      // The operation must be rejected (isError) — symlink escape not allowed
+      const res = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(res.isError).toBe(true);
+
+      // The outside file must NOT have been overwritten
+      const outsideContent = await readFile(outsideFile, 'utf-8');
+      expect(outsideContent).toBe('original-secret');
+
+      await rm(outsideDir, { recursive: true, force: true });
+    });
+
+    it('still creates new files when no symlink conflict exists (regression guard)', async () => {
+      const tool = findTool(tools, 'memory_write');
+      const result = await tool.execute(
+        {
+          name: 'New Memory',
+          description: 'A brand new memory',
+          type: 'project',
+          content: 'Some content.',
+        },
+        signal,
+      );
+      const text = typeof result === 'string' ? result : result.content;
+      expect(text).toContain('new-memory.md');
+      await access(join(tempDir, 'new-memory.md'));
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #114

## Problema
`memory_write` usava `safeJoin` (validação string-only, sem `realpath`) enquanto todas as outras operações do módulo (`memory_read`, `memory_edit`, `memory_delete`) já usavam `safeJoinResolved`. Um symlink colocado dentro do memoryDir apontando para arquivo externo seria seguido pelo `writeFile`, permitindo escrita arbitrária no filesystem.

## Abordagem TDD
- Teste em: `tests/unit/memory/memory-tools.test.ts` (describe `memory_write symlink traversal (issue #114)`)
- Falha antes do fix (red): `memory_write` seguia o symlink e não retornava `isError`
- Implementação mínima em: `src/memory/memory-tools.ts` — substituído `safeJoin(filename)` por `await safeJoinResolved(filename)` e removida a closure `safeJoin` agora sem uso
- Suíte completa: 834 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. Remoção de `safeJoin` não é mudança de regra — era código de defesa interno sem uso externo.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJmm5d3HzCKEqiFY1yLGJ1)_