### PR TITLE
fix: listAll() aplica LIMIT 10_000 para prevenir OOM (closes #116)

### DIFF
--- a/src/knowledge/sqlite-vector-store.ts
+++ b/src/knowledge/sqlite-vector-store.ts
@@ -6,6 +6,9 @@ import { cosineSimilarity } from '../utils/vector-math.js';
 /** Maximum rows scanned per search call to bound memory usage. */
 const MAX_SCAN = 10_000;
 
+/** Maximum rows returned by listAll() to prevent OOM on large knowledge bases. */
+const MAX_LIST_ALL = 10_000;
+
 /**
  * SQLite implementation of VectorStore with brute-force cosine similarity.
  */
@@ -82,7 +85,9 @@ export class SQLiteVectorStore implements VectorStore {
   }
 
   listAll(): KnowledgeChunk[] {
-    const rows = this.database.db.prepare('SELECT * FROM vectors').all() as VectorRow[];
+    const rows = this.database.db
+      .prepare('SELECT * FROM vectors ORDER BY created_at ASC LIMIT ?')
+      .all(MAX_LIST_ALL) as VectorRow[];
     return rows.map((row) => ({
       id: row.id,
       content: row.content,

--- a/tests/unit/knowledge/sqlite-vector-store.test.ts
+++ b/tests/unit/knowledge/sqlite-vector-store.test.ts
@@ -109,4 +109,37 @@ describe('SQLiteVectorStore', () => {
     expect(scanSql).toMatch(/LIMIT/);
     prepareSpy.mockRestore();
   });
+
+  it('listAll() uses a LIMIT clause to prevent OOM with large knowledge bases (issue #116)', () => {
+    const prepareSpy = vi.spyOn(database.db, 'prepare');
+    store.listAll();
+    const sqlCalls = prepareSpy.mock.calls.map((c) => c[0].toUpperCase());
+    const listSql = sqlCalls.find((sql) => sql.includes('FROM VECTORS'));
+    expect(listSql).toBeDefined();
+    expect(listSql).toMatch(/LIMIT/);
+    prepareSpy.mockRestore();
+  });
+
+  it('listAll() returns at most MAX_LIST_ALL rows even when more exist (issue #116)', () => {
+    // Insert 15 chunks — with MAX_LIST_ALL=10_000 this won't hit the cap in
+    // normal tests, but we verify the returned count never exceeds what we insert.
+    // The important contract is that the LIMIT is applied at SQL level (verified above).
+    for (let i = 0; i < 15; i++) {
+      store.upsert(
+        createChunk({
+          id: `la-${i}`,
+          content: `content ${i}`,
+          embedding: new Float32Array([i / 15, 0, 0, 0]),
+        }),
+      );
+    }
+    const all = store.listAll();
+    expect(all.length).toBe(15);
+    // Each returned chunk must be a valid KnowledgeChunk
+    for (const chunk of all) {
+      expect(chunk).toHaveProperty('id');
+      expect(chunk).toHaveProperty('content');
+      expect(chunk.embedding).toBeInstanceOf(Float32Array);
+    }
+  });
 });


### PR DESCRIPTION
## Issue
Closes #116

## Problema
`SQLiteVectorStore.listAll()` executava `SELECT * FROM vectors` sem cláusula LIMIT, carregando toda a tabela de vetores em memória. Com 100.000 documentos e embeddings de 6KB cada, isso representa ~600MB alocados de uma vez. O método `search()` na mesma classe já aplicava `LIMIT MAX_SCAN=10_000` corretamente.

## Abordagem TDD
- Teste em: `tests/unit/knowledge/sqlite-vector-store.test.ts` (2 novos testes: verifica LIMIT no SQL e comportamento com 15 chunks)
- Falha antes do fix (red): SQL gerado por `listAll()` não continha `LIMIT`
- Implementação mínima em: `src/knowledge/sqlite-vector-store.ts` — adicionado `MAX_LIST_ALL = 10_000` e `ORDER BY created_at ASC LIMIT ?` na query
- Suíte completa: 834 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. A ordenação `ASC` preserva o comportamento existente dos testes.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJmm5d3HzCKEqiFY1yLGJ1)_