### PR TITLE
fix: sql-tool-factory usa logger injetável em vez de console.error (closes #117)

### DIFF
--- a/src/tools/sql/sql-tool-factory.ts
+++ b/src/tools/sql/sql-tool-factory.ts
@@ -39,6 +39,9 @@ export interface SqlToolFactoryOptions {
 
   /** Prefix for tool names. Default: '' (empty). */
   toolNamePrefix?: string;
+
+  /** Logger used for query execution errors. Defaults to console.error. */
+  logger?: { error: (msg: string, meta?: unknown) => void };
 }
 
 /** SQL statements that mutate state — used to derive isReadOnly/isConcurrencySafe flags. */
@@ -58,6 +61,9 @@ export function createSqlTools(options: SqlToolFactoryOptions): AgentTool[] {
     defaultTimeoutMs = 30_000,
     toolNamePrefix = '',
   } = options;
+  const log = options.logger ?? {
+    error: (msg: string, meta?: unknown) => console.error(msg, meta),
+  };
 
   const queryMap = new Map<string, SqlQueryDef>();
   for (const q of queries) {
@@ -190,7 +196,10 @@ export function createSqlTools(options: SqlToolFactoryOptions): AgentTool[] {
         const genericMessage = pgCode
           ? `Query execution failed (error code: ${pgCode})`
           : 'Query execution failed';
-        console.error('[SqlTool] query execution error:', err);
+        log.error('[SqlTool] query execution error', {
+          pgCode,
+          message: (err as Error).message,
+        });
         return { content: genericMessage, isError: true };
       }
     },

--- a/tests/unit/tools/sql-tool-factory.test.ts
+++ b/tests/unit/tools/sql-tool-factory.test.ts
@@ -201,10 +201,10 @@ describe('createSqlTools', () => {
         query: vi.fn().mockRejectedValue(new Error('connection refused')),
       };
       const [, run] = createSqlTools({ pool, queries: sampleQueries });
-      const result = await run!.execute(
+      const result = (await run!.execute(
         { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
         AbortSignal.timeout(5000),
-      ) as { content: string; isError: boolean };
+      )) as { content: string; isError: boolean };
       expect(result.isError).toBe(true);
       expect(result.content).toMatch(/Query execution failed/);
     });
@@ -217,10 +217,10 @@ describe('createSqlTools', () => {
       );
       const pool: SqlQueryRunner = { query: vi.fn().mockRejectedValue(sensitiveError) };
       const [, run] = createSqlTools({ pool, queries: sampleQueries });
-      const result = await run!.execute(
+      const result = (await run!.execute(
         { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
         AbortSignal.timeout(5000),
-      ) as { content: string; isError: boolean };
+      )) as { content: string; isError: boolean };
 
       expect(result.isError).toBe(true);
       // Sensitive column/table names must not appear in the LLM-facing message
@@ -236,10 +236,10 @@ describe('createSqlTools', () => {
       );
       const pool: SqlQueryRunner = { query: vi.fn().mockRejectedValue(pgError) };
       const [, run] = createSqlTools({ pool, queries: sampleQueries });
-      const result = await run!.execute(
+      const result = (await run!.execute(
         { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
         AbortSignal.timeout(5000),
-      ) as { content: string; isError: boolean };
+      )) as { content: string; isError: boolean };
 
       expect(result.isError).toBe(true);
       // Error code is safe to include — it carries no structural info
@@ -250,5 +250,65 @@ describe('createSqlTools', () => {
     });
 
     // --- end issue #79 ---
+
+    // --- issue #117: sql-tool-factory usa console.error em vez do logger ---
+
+    it('uses injected logger.error instead of console.error on query failure (issue #117)', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const loggerErrorSpy = vi.fn();
+      const logger = { error: loggerErrorSpy };
+
+      const pool: SqlQueryRunner = {
+        query: vi.fn().mockRejectedValue(new Error('connection refused')),
+      };
+      const [, run] = createSqlTools({ pool, queries: sampleQueries, logger });
+
+      await run!.execute(
+        { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
+        AbortSignal.timeout(5000),
+      );
+
+      expect(loggerErrorSpy).toHaveBeenCalled();
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('logger.error receives structured meta with pgCode and message — not raw error (issue #117)', async () => {
+      const loggerErrorSpy = vi.fn();
+      const logger = { error: loggerErrorSpy };
+
+      const pgError = Object.assign(new Error('sensitive db detail'), { code: '23505' });
+      const pool: SqlQueryRunner = { query: vi.fn().mockRejectedValue(pgError) };
+      const [, run] = createSqlTools({ pool, queries: sampleQueries, logger });
+
+      await run!.execute(
+        { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
+        AbortSignal.timeout(5000),
+      );
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ pgCode: '23505' }),
+      );
+    });
+
+    it('falls back to console.error when no logger provided (backward compat) (issue #117)', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const pool: SqlQueryRunner = {
+        query: vi.fn().mockRejectedValue(new Error('connection refused')),
+      };
+      const [, run] = createSqlTools({ pool, queries: sampleQueries });
+
+      await run!.execute(
+        { query_name: 'sales_revenue_by_month', params: { product_id: 1 } },
+        AbortSignal.timeout(5000),
+      );
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    // --- end issue #117 ---
   });
 });


### PR DESCRIPTION
## Issue
Closes #117

## Problema
`sql-tool-factory` usava `console.error` diretamente no catch do `run_query`, violando: (1) a convenção do projeto que exige logger do projeto, (2) o campo `logLevel` configurado no Agent era ignorado, (3) sem `traceId` para correlação de erros, (4) o objeto `err` completo (com possível query SQL e stack trace) era logado sem controle de nível.

## Abordagem TDD
- Teste em: `tests/unit/tools/sql-tool-factory.test.ts` (3 novos testes na seção `issue #117`)
- Falha antes do fix (red): `loggerErrorSpy` não era chamado; `console.error` era sempre invocado
- Implementação mínima em: `src/tools/sql/sql-tool-factory.ts` — adicionado campo `logger?` em `SqlToolFactoryOptions`; o catch usa `log.error(msg, { pgCode, message })` em vez de `console.error(msg, err)`
- Suíte completa: 835 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. `logger` é campo opcional — backward compat mantida via fallback para `console.error`.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJmm5d3HzCKEqiFY1yLGJ1)_