### PR TITLE
fix: força ip-address>=10.1.1 via overrides para CVE-2026-42338 (closes #115)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,13 +79,15 @@
   "overrides": {
     "hono": ">=4.12.14",
     "@hono/node-server": ">=1.19.13",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "ip-address": ">=10.1.1"
   },
   "pnpm": {
     "overrides": {
       "hono": ">=4.12.14",
       "@hono/node-server": ">=1.19.13",
-      "postcss": ">=8.5.10"
+      "postcss": ">=8.5.10",
+      "ip-address": ">=10.1.1"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   hono: '>=4.12.14'
   '@hono/node-server': '>=1.19.13'
   postcss: '>=8.5.10'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -2160,8 +2161,8 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5313,7 +5314,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
     optional: true
 
   express@5.2.1:
@@ -5603,7 +5604,7 @@ snapshots:
 
   ini@4.1.1: {}
 
-  ip-address@10.1.0:
+  ip-address@10.2.0:
     optional: true
 
   ipaddr.js@1.9.1:

--- a/tests/unit/package-security.test.ts
+++ b/tests/unit/package-security.test.ts
@@ -36,6 +36,21 @@ describe('package.json security overrides (issue #26)', () => {
   });
 });
 
+describe('pnpm overrides — CVE-2026-42338 ip-address XSS (issue #115)', () => {
+  it('should pin ip-address to >=10.1.1 in pnpm.overrides to fix CVE-2026-42338', () => {
+    const pnpmSection = pkg.pnpm as { overrides?: Record<string, string> } | undefined;
+    const overrides = pnpmSection?.overrides ?? {};
+    expect(overrides).toHaveProperty('ip-address');
+    expect(overrides['ip-address']).toBe('>=10.1.1');
+  });
+
+  it('should also pin ip-address in top-level overrides for npm compatibility (issue #115)', () => {
+    const overrides = pkg.overrides as Record<string, string>;
+    expect(overrides).toHaveProperty('ip-address');
+    expect(overrides['ip-address']).toBe('>=10.1.1');
+  });
+});
+
 describe('release.yml safe sync — no destructive reset (issue #89)', () => {
   it('does NOT use git reset --hard in the bump/version step', () => {
     // git reset --hard silently discards any commits that landed between fetch and reset,


### PR DESCRIPTION
## Issue
Closes #115

## Problema
A dependência transitiva `ip-address@10.1.0` (caminho: `@modelcontextprotocol/sdk > express-rate-limit > ip-address`) tinha CVE-2026-42338 (XSS via métodos `Address6.group()`, `Address6.link()`). Embora o SDK seja backend-only e não renderize HTML, a presença da CVE pode bloquear pipelines de segurança de consumidores downstream.

## Abordagem TDD
- Teste em: `tests/unit/package-security.test.ts` (describe `pnpm overrides — CVE-2026-42338 ip-address XSS`)
- Falha antes do fix (red): `pnpm.overrides["ip-address"]` e `overrides["ip-address"]` ausentes
- Implementação mínima em: `package.json` — adicionado `"ip-address": ">=10.1.1"` em `overrides` (npm compat) e `pnpm.overrides`; `pnpm install` atualizou o lockfile para `ip-address@10.2.0`
- Suíte completa: 834 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. Override de dependência segue o padrão já estabelecido (hono, postcss, @hono/node-server).

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJmm5d3HzCKEqiFY1yLGJ1)_