### PR TITLE
chore(security): adiciona Socket.dev pra detectar pacotes npm maliciosos

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,51 @@
+name: Socket Security
+
+# Detecta packages npm maliciosos (typosquatting, install scripts maliciosos,
+# pacotes sequestrados) — categoria que npm audit / Dependabot / Semgrep / CodeQL
+# NAO cobrem.
+#
+# Dois caminhos de integracao:
+#  1. GitHub App (recomendado pra OSS, gratis): instale em
+#     https://github.com/apps/socket-security
+#     Esse workflow eh um no-op nesse caso — o App comenta direto nos PRs.
+#  2. CLI com SOCKET_SECURITY_API_KEY: setar o secret no repo ativa o scan
+#     deste workflow. Util pra hard-fail em caso de risco alto.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  socket:
+    name: Socket
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+
+      - name: Run Socket Security scan
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+        run: |
+          if [ -z "$SOCKET_SECURITY_API_KEY" ]; then
+            echo "::warning title=Socket not configured::SOCKET_SECURITY_API_KEY secret not set."
+            echo "::warning::Recommended: install Socket GitHub App for free OSS integration:"
+            echo "::warning::  https://github.com/apps/socket-security"
+            echo "::warning::Alternative: register at https://socket.dev and add SOCKET_SECURITY_API_KEY secret."
+            exit 0
+          fi
+          npx --yes @socketsecurity/cli@1 scan create --json --view


### PR DESCRIPTION
## Sumário

Adiciona **Socket.dev** ao pipeline de segurança como 6ª camada — pega categoria de ataque que `npm audit` / Dependabot / Semgrep / CodeQL **não cobrem**:

- Typosquatting (`expresss`, `lodahs` se passando por libs reais)
- `postinstall` scripts maliciosos que rodam `curl | bash`
- Pacotes sequestrados (mantenedor original perdeu acesso)
- Sleeper attacks (pacote muda comportamento depois de N downloads, tipo `event-stream`/`colors`)

## Caminhos de integração (escolha um, ou ambos)

| Caminho | Setup | Quando usar |
|---|---|---|
| **GitHub App** (recomendado pra OSS) | 1 clique em https://github.com/apps/socket-security | Detecção automática + comments em PR, free pra public repos |
| **CLI no workflow** | Setar secret `SOCKET_SECURITY_API_KEY` (registrar em https://socket.dev) | Hard-fail no CI em risco alto, controle programático |

O workflow `socket.yml` é gracioso: roda como **no-op com warning** se nenhum dos dois estiver configurado, ativa o scan via CLI quando o secret está presente. Não bloqueia merges enquanto o setup não acontecer.

## Próximo passo do seu lado

**Mínimo recomendado:** instalar o GitHub App (1 clique). Cobre 95% do valor sem precisar tocar em CI.

## Verificação

- [x] YAML válido (`python3 -c yaml.safe_load`)
- [x] Action SHA pinada
- [x] Skip dependabot (bot não introduz packages maliciosos)
- [ ] CI: workflow roda no PR (vai sair warning sobre missing secret — é o esperado)
- [ ] Após merge: instalar Socket GitHub App OU configurar `SOCKET_SECURITY_API_KEY` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)