### PR TITLE
chore: adiciona size-limit pra detectar regressão de bundle

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check bundle size
+        run: pnpm size
+
       - name: Test with coverage
         run: pnpm test:coverage
 

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "dist/ total (raw + gzipped via tar)",
+    "path": "dist/**/*.{js,d.ts}",
+    "limit": "500 KB",
+    "brotli": false,
+    "gzip": false
+  },
+  {
+    "name": "dist/index.js (main entry, raw)",
+    "path": "dist/index.js",
+    "limit": "5 KB",
+    "brotli": false,
+    "gzip": false
+  },
+  {
+    "name": "dist/agent.js (Agent class, raw)",
+    "path": "dist/agent.js",
+    "limit": "50 KB",
+    "brotli": false,
+    "gzip": false
+  }
+]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "validate:publish": "publint && attw --pack . --ignore-rules cjs-resolves-to-esm",
+    "size": "size-limit",
+    "size:why": "size-limit --why",
     "docs:dev": "cd documentation && npx mintlify@latest dev",
     "docs:build": "cd documentation && npx mintlify@latest build",
     "prepare": "husky"
@@ -53,6 +55,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.39.4",
+    "@size-limit/file": "^12.1.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/typescript-checker": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
@@ -69,6 +72,7 @@
     "lint-staged": "^15.5.2",
     "prettier": "^3.8.3",
     "publint": "^0.3.18",
+    "size-limit": "^12.1.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.59.2",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       '@stryker-mutator/core':
         specifier: ^9.6.1
         version: 9.6.1(@types/node@25.6.0)
@@ -84,6 +87,9 @@ importers:
       publint:
         specifier: ^0.3.18
         version: 0.3.19
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0(jiti@2.6.1)
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -1177,6 +1183,12 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@stryker-mutator/api@9.6.1':
     resolution: {integrity: sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==}
     engines: {node: '>=20.0.0'}
@@ -1478,6 +1490,10 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2629,6 +2645,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -3051,6 +3070,16 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -4463,6 +4492,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      size-limit: 12.1.0(jiti@2.6.1)
+
   '@stryker-mutator/api@9.6.1':
     dependencies:
       mutation-testing-metrics: 3.7.3
@@ -4872,6 +4905,8 @@ snapshots:
       ieee754: 1.2.1
 
   builtin-modules@3.3.0: {}
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -6030,6 +6065,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
@@ -6571,6 +6610,16 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  size-limit@12.1.0(jiti@2.6.1):
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      jiti: 2.6.1
 
   skin-tone@2.0.0:
     dependencies:


### PR DESCRIPTION
## Sumário

Adiciona **size-limit** ao pipeline pra detectar inchaço de bundle silencioso.

## Configuração

Lib é Node-only (usa `node:fs`, `node:crypto`, `better-sqlite3` nativo). Esbuild/webpack tentam bundlar como browser e falham nos imports `node:*`. Solução: `@size-limit/file` (mede tamanho real, sem bundling) — é o que importa pra consumidor de lib npm.

### Budgets

| Alvo | Atual | Limite | Headroom |
|---|---|---|---|
| `dist/` total | 418.48 KB | 500 KB | ~16% |
| `dist/index.js` (main entry) | 2.45 KB | 5 KB | grande |
| `dist/agent.js` (Agent class) | 32.79 KB | 50 KB | ~34% |

## CI

Step `Check bundle size` adicionado ao `pr-check.yml` entre build e test. Bloqueia merge se ultrapassar budget.

## Scripts

```
pnpm size       # checa budgets
pnpm size:why   # análise detalhada (qual arquivo cresceu)
```

## Verificação

- [x] pnpm size — todos sob budget
- [x] pnpm lint, typecheck, test — verde
- [ ] CI valida o novo step

🤖 Generated with [Claude Code](https://claude.com/claude-code)