### PR TITLE
fix(ci): socket scan trava em prompt interativo sem --org

### DIFF
--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run Socket Security scan
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          # SOCKET_ORG: nome da organizacao em socket.dev. Se nao for setado
+          # via repo variable, default eh 'agentx-sdk' (org criada automaticamente).
+          SOCKET_ORG: ${{ vars.SOCKET_ORG || 'agentx-sdk' }}
         run: |
           if [ -z "$SOCKET_SECURITY_API_KEY" ]; then
             echo "::warning title=Socket not configured::SOCKET_SECURITY_API_KEY secret not set."
@@ -48,4 +51,9 @@ jobs:
             echo "::warning::Alternative: register at https://socket.dev and add SOCKET_SECURITY_API_KEY secret."
             exit 0
           fi
-          npx --yes @socketsecurity/cli@1 scan create --json --view
+          # --org evita prompt interativo (CLI bloqueia o run em CI sem isso).
+          # --no-interactive falha em qualquer prompt em vez de pendurar.
+          npx --yes @socketsecurity/cli@1 scan create \
+            --org "$SOCKET_ORG" \
+            --no-interactive \
+            --view


### PR DESCRIPTION
## Sumário

A CLI `@socketsecurity/cli@1` pede org name **interativamente** quando o token não tem org default associada. Em GitHub Actions o stdin não tem TTY → o prompt fica pendurado e o workflow termina como "success" sem escanear nada.

## Fix

Passa `--org` explícito + `--no-interactive`:

```yaml
env:
  SOCKET_ORG: ${{ vars.SOCKET_ORG || 'agentx-sdk' }}
run: |
  npx --yes @socketsecurity/cli@1 scan create \
    --org "$SOCKET_ORG" \
    --no-interactive \
    --view
```

- `SOCKET_ORG` repo variable permite override sem editar o workflow
- Default `agentx-sdk` (org criada automaticamente quando você assinou)

## Como detectei

`gh workflow run socket.yml` (run #25450003471) — key autenticou OK, mas o log terminou em `"Missing org name; do you want to use any of these orgs..."` e o passo encerrou sem progredir pro scan real.

## Verificação

- [x] YAML válido
- [ ] CI re-roda Socket workflow neste PR — espera-se ver scan real (não mais prompt)
- [ ] Após merge: workflow no main exibe achados de pacotes maliciosos no log

🤖 Generated with [Claude Code](https://claude.com/claude-code)