### PR TITLE
fix(ci): socket-issues precisa de scan view além de scan create

### DIFF
--- a/.github/scripts/socket-create-issues.sh
+++ b/.github/scripts/socket-create-issues.sh
@@ -16,16 +16,27 @@ if [ ! -f "$SCAN_FILE" ]; then
 fi
 
 # Severity threshold: ajuste pra incluir 'medium' se quiser mais cobertura
-SEVERITY_FILTER='select(.severity == "critical" or .severity == "high")'
+SEVERITIES='["critical", "high"]'
 
 # Cache existing open issues pra dedup (1 API call vs N)
 gh issue list --label socket-finding --state open --json title --limit 200 \
   | jq -r '.[].title' > existing_titles.txt
 
-# Extract alerts. Defensive: se o shape do JSON mudar, falha graciosamente
-if ! jq -c "(.alerts // [])[] | $SEVERITY_FILTER" "$SCAN_FILE" > filtered_alerts.jsonl; then
-  echo "::warning::Nao foi possivel parsear alerts. Conteudo (500 chars):"
-  head -c 500 "$SCAN_FILE"
+# Extract alerts via recursao — Socket scan view pode aninhar em diferentes shapes
+# (artifacts[].alerts, alerts[], packages.<name>.alerts, etc). A recursao acha
+# qualquer objeto com 'severity' + 'type' (assinatura de alert).
+# Defensive: se nao houver alerts, gera arquivo vazio em vez de falhar.
+jq -c --argjson sev "$SEVERITIES" '
+  [.. | objects | select(.severity != null and .type != null)]
+  | unique
+  | .[]
+  | select(.severity as $s | $sev | index($s))
+' "$SCAN_FILE" > filtered_alerts.jsonl 2>/dev/null || true
+
+if [ ! -s filtered_alerts.jsonl ]; then
+  echo "::notice::Nenhum alert de severity high/critical encontrado"
+  echo "Conteudo do scan (1000 chars):"
+  head -c 1000 "$SCAN_FILE"
   exit 0
 fi
 

--- a/.github/workflows/socket-issues.yml
+++ b/.github/workflows/socket-issues.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
 
-      - name: Run Socket scan
+      - name: Run Socket scan (create + view)
         id: scan
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
@@ -45,11 +45,31 @@ jobs:
             echo "::error::SOCKET_SECURITY_API_KEY nao setado"
             exit 1
           fi
+          # 1. Create scan — retorna metadata (id, status, etc)
           npx --yes @socketsecurity/cli@1 scan create \
             --org "$SOCKET_ORG" \
             --no-interactive \
+            --json > scan-create.json || {
+              echo "::warning::Scan create falhou — pulando"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+          # 2. Extract scan ID — campo pode ser .id ou .scan_id, defensive
+          SCAN_ID=$(jq -r '.id // .scan_id // .data.id // empty' scan-create.json)
+          if [ -z "$SCAN_ID" ]; then
+            echo "::warning::Nao consegui extrair scan ID. Conteudo:"
+            head -c 1000 scan-create.json
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "scan_id=$SCAN_ID" >> "$GITHUB_OUTPUT"
+          echo "Scan ID: $SCAN_ID"
+          # 3. View scan — retorna alerts completos (a estrutura real que o script parseia)
+          npx --yes @socketsecurity/cli@1 scan view "$SCAN_ID" \
+            --org "$SOCKET_ORG" \
+            --no-interactive \
             --json > scan.json || {
-              echo "::warning::Scan falhou — pulando criacao de issues"
+              echo "::warning::Scan view falhou — pulando"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             }


### PR DESCRIPTION
## Sumário

`socket scan create` retorna apenas metadata (id, status). Pra obter os alerts completos é preciso `scan view <id> --json`.

Detectado via run #25450804825 — workflow saiu OK com "Criadas 0 issues" porque o `scan.json` só tinha o metadata.

## Mudanças

### `socket-issues.yml`

Workflow agora é **2-step**:
1. `scan create --json > scan-create.json` → extrai `scan_id`
2. `scan view <id> --json > scan.json` → pega alerts pra parsing

### `socket-create-issues.sh`

Script ficou mais **robusto** ao formato JSON:

- jq usa **recursão** (`..`) pra achar alerts em qualquer nível da árvore. Socket pode aninhar em `artifacts[].alerts`, `packages.<name>.alerts`, etc — não precisamos saber o shape exato.
- Filter de severity passa como `--argjson` em vez de interpolar string

```jq
[.. | objects | select(.severity != null and .type != null)]
| unique
| .[]
| select(.severity as $s | $sev | index($s))
```

## Test plan

- [ ] CI verde no PR
- [ ] Após merge: `gh workflow run socket-issues.yml` → ver issues criadas (se houver findings high/critical)
- [ ] Se 0 findings: log mostra `"Nenhum alert de severity high/critical encontrado"` + 1000 chars do scan pra debug

🤖 Generated with [Claude Code](https://claude.com/claude-code)