### PR TITLE
fix(ci): socket-issues usa .data[] (formato real do socket scan view)

### DIFF
--- a/.github/scripts/socket-create-issues.sh
+++ b/.github/scripts/socket-create-issues.sh
@@ -27,23 +27,16 @@ gh label create "severity:high" --color "d93f0b" --description "Severity: high" 
 gh issue list --label socket-finding --state open --json title --limit 200 \
   | jq -r '.[].title' > existing_titles.txt
 
-# Extract alerts. Socket scan view geralmente aninha alerts em artifacts[].alerts,
-# onde o package name+version sao do artifact (parent). Walk artifacts e emite
-# {...alert, package, version} pra cada combinacao.
-# Fallback: se nao houver artifacts, recursao no JSON inteiro pra achar alerts soltos.
+# Extract alerts. Socket scan view retorna { ok: true, data: [{ name, version, alerts: [...] }, ...] }.
+# Aceita tambem .artifacts[].alerts (formato alternativo) como fallback defensivo.
+# Cada alert eh enriquecido com package/version do artifact pai pra titulo do issue.
 jq -c --argjson sev "$SEVERITIES" '
-  # Tenta artifacts (formato comum do scan view)
-  if (.artifacts // empty) | length > 0 then
-    .artifacts[] as $art
-    | ($art.alerts // [])[]
-    | . + {
-        package: ($art.name // $art.package // "unknown"),
-        version: ($art.version // ""),
-      }
-  # Fallback: recursao no JSON inteiro
-  else
-    [.. | objects | select(.severity != null and .type != null)] | .[]
-  end
+  ((.data // .artifacts // []) | select(type == "array") | .[]) as $art
+  | ($art.alerts // []) | .[]
+  | . + {
+      package: ($art.name // $art.package // "unknown"),
+      version: ($art.version // ""),
+    }
   | select(.severity as $s | $sev | index($s))
 ' "$SCAN_FILE" > filtered_alerts.jsonl 2>/dev/null || true
 


### PR DESCRIPTION
## Bug

Workflow rodava sem criar issues mesmo quando o Socket detectava findings.

**Causa raiz:** o script assumia que `socket scan view` retornava `{ artifacts: [...] }`, mas o formato real é `{ ok: true, data: [...] }`.

Plus: o `if (.artifacts // empty) | length > 0` tinha comportamento ambíguo no jq quando `.artifacts` era undefined — `empty` em condicional pode produzir empty output sem cair em then nem else.

## Como detectei

Run [#25451307398](https://github.com/DouglasPrado/agentx-sdk/actions/runs/25451307398) — log do debug `head -c 1500 scan.json` revelou:

```json
{
  "ok": true,
  "data": [
    { "name": "estraverse", "version": "5.3.0", "alerts": [], ... },
    { "name": "strip-ansi", ...
```

## Fix

jq mais simples e defensivo que aceita ambos os formatos:

```jq
((.data // .artifacts // []) | select(type == "array") | .[]) as $art
| ($art.alerts // []) | .[]
| . + { package: $art.name, version: $art.version }
| select(.severity as $s | $sev | index($s))
```

## Test plan

- [x] jq testado localmente com sample (extrai corretamente)
- [ ] CI verde
- [ ] Após merge: `gh workflow run socket-issues.yml` cria issues pra cada finding ≥ high (se houver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)