### PR TITLE
fix(ci): socket-issues evita duplicatas dentro do mesmo run

### DIFF
--- a/.github/scripts/socket-create-issues.sh
+++ b/.github/scripts/socket-create-issues.sh
@@ -56,11 +56,23 @@ while IFS= read -r alert; do
   pkg=$(echo "$alert" | jq -r '.package // .pkg // "unknown"')
   ver=$(echo "$alert" | jq -r '.version // .ver // ""')
   description=$(echo "$alert" | jq -r '.description // .message // ""')
+  # File path dentro do package (ex: "package/dist/foo.js") — distingue alerts
+  # diferentes do mesmo pkg/version. Pega so o basename pra titulo legivel.
+  file_path=$(echo "$alert" | jq -r '.file // ""')
+  file_basename=""
+  if [ -n "$file_path" ] && [ "$file_path" != "null" ]; then
+    file_basename=$(basename "$file_path")
+  fi
 
+  # Titulo: "[socket] <type>: <pkg>@<ver> (<file>)" se file existir
+  base_title="[socket] $type: $pkg"
   if [ -n "$ver" ] && [ "$ver" != "null" ]; then
-    title="[socket] $type: $pkg@$ver"
+    base_title="$base_title@$ver"
+  fi
+  if [ -n "$file_basename" ]; then
+    title="$base_title ($file_basename)"
   else
-    title="[socket] $type: $pkg"
+    title="$base_title"
   fi
 
   if grep -Fxq "$title" existing_titles.txt; then
@@ -92,6 +104,8 @@ while IFS= read -r alert; do
     --label "socket-finding" \
     --label "severity:$severity"; then
     count=$((count + 1))
+    # Within-run dedup: alerts subsequentes com mesmo titulo ja sao skipados
+    echo "$title" >> existing_titles.txt
   else
     echo "::warning::Falha ao criar issue: $title"
   fi


### PR DESCRIPTION
Run #25454987241 criou 3 issues mas #132 e #133 viraram duplicatas (mesmo título). Causa: `existing_titles.txt` é montado uma vez antes do loop, e issues criadas dentro do loop não são adicionadas.

## Fixes

1. **Título inclui basename do file** quando alert tem campo `file`:
   - Antes: `[socket] obfuscatedFile: markdown-it@14.1.1`
   - Depois: `[socket] obfuscatedFile: markdown-it@14.1.1 (markdown-it.js)`

2. **Append ao existing_titles.txt** após cada issue criada — within-run dedup

Issue #133 fechada manualmente como duplicata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)