### PR TITLE
fix: bloqueia CGNAT 100.64.0.0/10 no ssrf-guard (closes #141)

### DIFF
--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -36,6 +36,7 @@ export function validateSsrfUrl(rawUrl: string): string | null {
     if (a === 192 && b === 168) return 'Blocked private range 192.168.0.0/16';
     if (a === 172 && b >= 16 && b <= 31) return 'Blocked private range 172.16.0.0/12';
     if (a === 169 && b === 254) return 'Blocked link-local range (cloud metadata)';
+    if (a === 100 && b >= 64 && b <= 127) return 'Blocked shared address space 100.64.0.0/10';
     if (a === 0) return 'Blocked 0.0.0.0/8';
   }
 

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { validateSsrfUrl } from '../../../src/utils/ssrf-guard.js';
+
+describe('validateSsrfUrl', () => {
+  it('allows public IPv4', () => {
+    expect(validateSsrfUrl('https://1.1.1.1/')).toBeNull();
+    expect(validateSsrfUrl('https://8.8.8.8/')).toBeNull();
+  });
+
+  it('blocks loopback 127.x', () => {
+    expect(validateSsrfUrl('http://127.0.0.1/')).not.toBeNull();
+    expect(validateSsrfUrl('http://127.1.2.3/')).not.toBeNull();
+  });
+
+  it('blocks 10.0.0.0/8', () => {
+    expect(validateSsrfUrl('http://10.0.0.1/')).not.toBeNull();
+    expect(validateSsrfUrl('http://10.255.255.255/')).not.toBeNull();
+  });
+
+  it('blocks 172.16.0.0/12', () => {
+    expect(validateSsrfUrl('http://172.16.0.1/')).not.toBeNull();
+    expect(validateSsrfUrl('http://172.31.255.255/')).not.toBeNull();
+  });
+
+  it('blocks 192.168.0.0/16', () => {
+    expect(validateSsrfUrl('http://192.168.1.1/')).not.toBeNull();
+  });
+
+  it('blocks link-local 169.254.0.0/16', () => {
+    expect(validateSsrfUrl('http://169.254.169.254/')).not.toBeNull();
+  });
+
+  it('blocks 0.0.0.0/8', () => {
+    expect(validateSsrfUrl('http://0.0.0.1/')).not.toBeNull();
+  });
+
+  it('blocks localhost hostname', () => {
+    expect(validateSsrfUrl('http://localhost/')).not.toBeNull();
+  });
+
+  it('blocks non-http/https schemes', () => {
+    expect(validateSsrfUrl('file:///etc/passwd')).not.toBeNull();
+    expect(validateSsrfUrl('ftp://example.com/')).not.toBeNull();
+  });
+
+  // issue #141 — RFC 6598 Shared Address Space (CGNAT) 100.64.0.0/10
+  describe('CGNAT shared address space 100.64.0.0/10 (issue #141)', () => {
+    it('blocks 100.64.0.1 (start of CGNAT range)', () => {
+      expect(validateSsrfUrl('http://100.64.0.1/')).not.toBeNull();
+    });
+
+    it('blocks 100.100.0.1 (mid CGNAT range)', () => {
+      expect(validateSsrfUrl('http://100.100.0.1/')).not.toBeNull();
+    });
+
+    it('blocks 100.127.255.255 (end of CGNAT range)', () => {
+      expect(validateSsrfUrl('http://100.127.255.255/')).not.toBeNull();
+    });
+
+    it('allows 100.63.255.255 (just below CGNAT range)', () => {
+      expect(validateSsrfUrl('http://100.63.255.255/')).toBeNull();
+    });
+
+    it('allows 100.128.0.0 (just above CGNAT range)', () => {
+      expect(validateSsrfUrl('http://100.128.0.0/')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Issue
Closes #141

## Problema
O `ssrf-guard.ts` bloqueava as faixas privadas clássicas (10.x, 172.16-31.x, 192.168.x, 169.254.x) mas não bloqueava `100.64.0.0/10` (RFC 6598 — Shared Address Space / CGNAT). Essa faixa é usada por provedores cloud e ISPs e pode hospedar serviços internos acessíveis a partir do servidor, configurando um vetor de SSRF.

## Abordagem TDD
- Teste em: `tests/unit/utils/ssrf-guard.test.ts` — bloco `CGNAT shared address space 100.64.0.0/10 (issue #141)`
- Falha antes do fix (red): 3 testes falhando — `100.64.0.1`, `100.100.0.1`, `100.127.255.255` retornavam `null` (permitido) em vez de erro
- Implementação mínima em: `src/utils/ssrf-guard.ts:38` — uma linha adicionada: `if (a === 100 && b >= 64 && b <= 127) return 'Blocked shared address space 100.64.0.0/10';`
- Suíte completa: 862 testes verdes (falha pré-existente em `teams-bot/agent-factory.test.ts`)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MTyqUA4MxDxefaWz9icFQ)_