### PR TITLE
fix: guards explícitos para command/url em MCPAdapter (closes #142)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -601,24 +601,28 @@ async function createTransport(config: MCPConnectionConfig): Promise<unknown> {
     : undefined;
 
   if (config.transport === 'stdio') {
+    if (!config.command) {
+      throw new Error('MCPConnectionConfig: "command" is required for transport "stdio"');
+    }
     const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
-    return new StdioClientTransport({ command: config.command!, args: config.args ?? [] });
+    return new StdioClientTransport({ command: config.command, args: config.args ?? [] });
   }
 
-  if (config.url) {
+  if (config.transport === 'sse' || config.transport === 'http') {
+    if (!config.url) {
+      throw new Error(`MCPConnectionConfig: "url" is required for transport "${config.transport}"`);
+    }
     const ssrfError = validateSsrfUrl(config.url);
     if (ssrfError) throw new Error(`MCP URL blocked (SSRF): ${ssrfError}`);
-  }
 
-  if (config.transport === 'sse') {
-    const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
-    return new SSEClientTransport(new URL(config.url!), { requestInit });
-  }
+    if (config.transport === 'sse') {
+      const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
+      return new SSEClientTransport(new URL(config.url), { requestInit });
+    }
 
-  if (config.transport === 'http') {
     const { StreamableHTTPClientTransport } =
       await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
-    return new StreamableHTTPClientTransport(new URL(config.url!), { requestInit });
+    return new StreamableHTTPClientTransport(new URL(config.url), { requestInit });
   }
 
   throw new Error(`Unsupported MCP transport: ${config.transport}`);

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -146,6 +146,27 @@ describe('MCPAdapter', () => {
         adapter.connect({ name: 'dup', transport: 'stdio', command: 'node' }),
       ).rejects.toThrow('already connected');
     });
+
+    // issue #142 — missing required fields must throw descriptive errors
+    describe('missing required config fields (issue #142)', () => {
+      it('throws descriptive error for stdio without command', async () => {
+        await expect(
+          adapter.connect({ name: 'no-cmd', transport: 'stdio' } as never),
+        ).rejects.toThrow(/"command".*stdio|stdio.*"command"/i);
+      });
+
+      it('throws descriptive error for sse without url', async () => {
+        await expect(
+          adapter.connect({ name: 'no-url', transport: 'sse' } as never),
+        ).rejects.toThrow(/"url".*sse|sse.*"url"/i);
+      });
+
+      it('throws descriptive error for http without url', async () => {
+        await expect(
+          adapter.connect({ name: 'no-url-http', transport: 'http' } as never),
+        ).rejects.toThrow(/"url".*http|http.*"url"/i);
+      });
+    });
   });
 
   describe('disconnect()', () => {
@@ -932,7 +953,7 @@ describe('MCPAdapter', () => {
           name: 'evil-sse',
           transport: 'sse',
           url: 'http://169.254.169.254/latest/meta-data/',
-        })
+        }),
       ).rejects.toThrow(/SSRF|blocked|private|link-local/i);
     });
 
@@ -942,7 +963,7 @@ describe('MCPAdapter', () => {
           name: 'evil-http',
           transport: 'http',
           url: 'http://10.0.0.1/admin',
-        })
+        }),
       ).rejects.toThrow(/SSRF|blocked|private/i);
     });
 
@@ -952,7 +973,7 @@ describe('MCPAdapter', () => {
           name: 'evil-auto',
           transport: 'auto',
           url: 'http://192.168.1.1/api',
-        })
+        }),
       ).rejects.toThrow(/SSRF|blocked|private/i);
     });
 


### PR DESCRIPTION
## Issue
Closes #142

## Problema
`createTransport` em `mcp-adapter.ts` usava non-null assertions (`config.command!`, `config.url!`) em campos opcionais sem validar sua presença antes. Para `stdio` sem `command`, o SDK MCP recebia `undefined` silenciosamente. Para `sse`/`http` sem `url`, a exceção resultante era `TypeError: Failed to construct 'URL': Invalid URL` — sem indicar qual campo estava faltando.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts` — bloco `missing required config fields (issue #142)`
- Falha antes do fix (red): `stdio` sem `command` não jogava exceção; `sse`/`http` sem `url` jogava `"Invalid URL"` sem contexto
- Implementação mínima em: `src/tools/mcp-adapter.ts:603-622` — guards adicionados antes de cada branch de transport, removendo non-null assertions
- Suíte completa: 851 testes verdes (falha pré-existente em `teams-bot/agent-factory.test.ts`)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MTyqUA4MxDxefaWz9icFQ)_