### PR TITLE
fix: bump hono override para >=4.12.16 (closes #143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,14 +84,14 @@
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "overrides": {
-    "hono": ">=4.12.14",
+    "hono": ">=4.12.16",
     "@hono/node-server": ">=1.19.13",
     "postcss": ">=8.5.10",
     "ip-address": ">=10.1.1"
   },
   "pnpm": {
     "overrides": {
-      "hono": ">=4.12.14",
+      "hono": ">=4.12.16",
       "@hono/node-server": ">=1.19.13",
       "postcss": ">=8.5.10",
       "ip-address": ">=10.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.14'
+  hono: '>=4.12.16'
   '@hono/node-server': '>=1.19.13'
   postcss: '>=8.5.10'
   ip-address: '>=10.1.1'
@@ -568,7 +568,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.16'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2144,8 +2144,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -4090,9 +4090,9 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@hono/node-server@1.19.13(hono@4.12.15)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
     optional: true
 
   '@humanfs/core@0.19.2':
@@ -4301,7 +4301,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.15)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4311,7 +4311,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5686,7 +5686,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.15:
+  hono@4.12.18:
     optional: true
 
   html-escaper@2.0.2: {}

--- a/tests/unit/package-security.test.ts
+++ b/tests/unit/package-security.test.ts
@@ -16,11 +16,11 @@ describe('package.json security overrides (issue #26)', () => {
     expect(typeof pkg.overrides).toBe('object');
   });
 
-  it('should pin hono to >=4.12.14 to fix GHSA-26pp, GHSA-r5rp, GHSA-xf4j, GHSA-wmmm, GHSA-458j, GHSA-xpcf', () => {
+  it('should pin hono to >=4.12.16 to fix GHSA-26pp, GHSA-r5rp, GHSA-xf4j, GHSA-wmmm, GHSA-458j, GHSA-xpcf, GHSA-9vqf, GHSA-69xw', () => {
     const overrides = pkg.overrides as Record<string, string>;
     expect(overrides).toHaveProperty('hono');
-    // Must satisfy >=4.12.14 (the minimum safe version for all hono CVEs)
-    expect(overrides.hono).toBe('>=4.12.14');
+    // Must satisfy >=4.12.16 (minimum for all hono CVEs including issue #143)
+    expect(overrides.hono).toBe('>=4.12.16');
   });
 
   it('should pin @hono/node-server to >=1.19.13 to fix GHSA-92pp', () => {
@@ -33,6 +33,19 @@ describe('package.json security overrides (issue #26)', () => {
     const overrides = pkg.overrides as Record<string, string>;
     expect(overrides).toHaveProperty('postcss');
     expect(overrides.postcss).toBe('>=8.5.10');
+  });
+});
+
+describe('pnpm overrides — hono >=4.12.16 (GHSA-9vqf + GHSA-69xw) (issue #143)', () => {
+  it('pins hono to >=4.12.16 in pnpm.overrides to fix bodyLimit bypass and JSX HTML Injection', () => {
+    const pnpmSection = pkg.pnpm as { overrides?: Record<string, string> } | undefined;
+    const overrides = pnpmSection?.overrides ?? {};
+    expect(overrides.hono).toMatch(/^>=4\.12\.(1[6-9]|[2-9]\d|\d{3,})/);
+  });
+
+  it('pins hono to >=4.12.16 in top-level overrides for npm compatibility (issue #143)', () => {
+    const overrides = pkg.overrides as Record<string, string>;
+    expect(overrides.hono).toMatch(/^>=4\.12\.(1[6-9]|[2-9]\d|\d{3,})/);
   });
 });
 


### PR DESCRIPTION
## Issue
Closes #143

## Problema
O override de `hono` em `package.json` (tanto em `overrides` quanto em `pnpm.overrides`) estava em `>=4.12.14`, deixando 2 CVEs moderados expostos via dependência transitória `@modelcontextprotocol/sdk → hono`:
- **GHSA-9vqf-7f2p-gf9v**: `bodyLimit()` bypass em requisições chunked (fixado em `>=4.12.16`)
- **GHSA-69xw-7hcm-h432**: HTML Injection via `hono/jsx` com nomes de tag não validados (fixado em `>=4.12.16`)

## Abordagem TDD
- Teste em: `tests/unit/package-security.test.ts` — bloco `pnpm overrides — hono >=4.12.16 (GHSA-9vqf + GHSA-69xw) (issue #143)`
- Falha antes do fix (red): override era `>=4.12.14`, abaixo do mínimo `>=4.12.16`
- Implementação mínima em: `package.json` — duas ocorrências de `"hono": ">=4.12.14"` → `"hono": ">=4.12.16"`
- Suíte completa: 850 testes verdes (falha pré-existente em `teams-bot/agent-factory.test.ts`)

## Mudanças de regras (justificativa)
O teste existente `should pin hono to >=4.12.14` foi atualizado para `>=4.12.16` — mudança mínima necessária para cobrir os novos CVEs da issue #143.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Mudança de regra justificada (bump de versão de segurança)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MTyqUA4MxDxefaWz9icFQ)_