### PR TITLE
fix: StreamingToolExecutor usa logger injetável em vez de console.warn (closes #144)

### DIFF
--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -1,5 +1,6 @@
 import type { ToolExecutor } from '../tools/tool-executor.js';
 import type { AgentToolResult } from '../contracts/entities/tool-call.js';
+import { createLogger, type Logger } from '../utils/logger.js';
 
 export interface ToolExecutionResult {
   id: string;
@@ -39,13 +40,15 @@ export class StreamingToolExecutor {
   private readonly tools: TrackedTool[] = [];
   private readonly executor: ToolExecutor;
   private readonly signal?: AbortSignal;
+  private readonly logger: Logger;
   private processing = false;
   /** Accumulated progress events from all tools (drained by getProgressEvents) */
   private pendingProgress: ToolProgressInfo[] = [];
 
-  constructor(executor: ToolExecutor, signal?: AbortSignal) {
+  constructor(executor: ToolExecutor, signal?: AbortSignal, logger?: Logger) {
     this.executor = executor;
     this.signal = signal;
+    this.logger = logger ?? createLogger({ prefix: 'streaming-tool-executor' });
   }
 
   /** Called during LLM streaming when a tool_call chunk arrives */
@@ -102,9 +105,7 @@ export class StreamingToolExecutor {
           // Defensive: an invariant violation upstream (status='completed' without
           // result/duration) shouldn't crash the whole stream. Mark as yielded so
           // we don't loop on it, log, and skip.
-          console.warn(
-            `[streaming-tool-executor] tool "${tool.id}" completed without result/duration — skipping`,
-          );
+          this.logger.warn(`tool "${tool.id}" completed without result/duration — skipping`);
           tool.status = 'yielded';
           continue;
         }
@@ -140,9 +141,7 @@ export class StreamingToolExecutor {
 
       if (tool.result === undefined || tool.duration === undefined) {
         // Same defensive skip as getCompletedResults — never crash the stream.
-        console.warn(
-          `[streaming-tool-executor] tool "${tool.id}" finished without result/duration — skipping`,
-        );
+        this.logger.warn(`tool "${tool.id}" finished without result/duration — skipping`);
         tool.status = 'yielded';
         continue;
       }

--- a/tests/unit/core/streaming-tool-executor.test.ts
+++ b/tests/unit/core/streaming-tool-executor.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import { StreamingToolExecutor } from '../../../src/core/streaming-tool-executor.js';
 import { ToolExecutor } from '../../../src/tools/tool-executor.js';
+import type { Logger } from '../../../src/utils/logger.js';
 import { z } from 'zod';
 import type { AgentTool } from '../../../src/contracts/entities/agent-tool.js';
+
+function makeLogger(): Logger & { warn: ReturnType<typeof vi.fn> } {
+  return {
+    level: 'warn' as const,
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
 
 function createTool(overrides: Partial<AgentTool> = {}): AgentTool {
   return {
@@ -415,5 +427,72 @@ describe('StreamingToolExecutor', () => {
     const completed = [...streaming.getCompletedResults()];
     expect(completed).toHaveLength(1);
     expect(completed[0]!.id).toBe('c1');
+  });
+
+  // issue #144 — defensive warnings must go through injected logger, not console.warn
+  describe('injected logger instead of console.warn (issue #144)', () => {
+    it('routes defensive warn to injected logger and not to console.warn (getCompletedResults)', () => {
+      const executor = new ToolExecutor();
+      const logger = makeLogger();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Pass logger as 3rd constructor arg (not yet accepted — RED phase)
+      const streaming = new StreamingToolExecutor(executor, undefined, logger);
+
+      // Inject a tool with status='completed' but missing result/duration (invariant violation)
+      // This forces the defensive warn path.
+      (streaming as unknown as { tools: unknown[] }).tools.push({
+        id: 'broken-1',
+        name: 'broken',
+        args: '{}',
+        parsedArgs: {},
+        isSafe: true,
+        status: 'completed',
+        result: undefined,
+        duration: undefined,
+        progressEvents: [],
+      });
+
+      const results = [...streaming.getCompletedResults()];
+      expect(results).toHaveLength(0); // Broken tool skipped
+
+      // After fix: console.warn must NOT be called; logger.warn must BE called
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledOnce();
+
+      warnSpy.mockRestore();
+    });
+
+    it('routes defensive warn to injected logger and not to console.warn (getRemainingResults)', async () => {
+      const executor = new ToolExecutor();
+      const logger = makeLogger();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const streaming = new StreamingToolExecutor(executor, undefined, logger);
+
+      (streaming as unknown as { tools: unknown[] }).tools.push({
+        id: 'broken-2',
+        name: 'broken',
+        args: '{}',
+        parsedArgs: {},
+        isSafe: true,
+        status: 'executing',
+        promise: Promise.resolve(),
+        result: undefined,
+        duration: undefined,
+        progressEvents: [],
+      });
+
+      const results: unknown[] = [];
+      for await (const r of streaming.getRemainingResults()) {
+        results.push(r);
+      }
+      expect(results).toHaveLength(0);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledOnce();
+
+      warnSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Issue
Closes #144

## Problema
`StreamingToolExecutor` usava `console.warn` diretamente em dois pontos de tratamento defensivo (`getCompletedResults` e `getRemainingResults`), bypassando a abstração de logger injetável que todo o resto do SDK usa. Em ambientes com log aggregation (Datadog, CloudWatch) ou em testes unitários, esses warnings escapam do pipeline de observabilidade configurado.

## Abordagem TDD
- Teste em: `tests/unit/core/streaming-tool-executor.test.ts` — bloco `injected logger instead of console.warn (issue #144)`
- Falha antes do fix (red): `console.warn` era chamado mesmo quando um logger mock era injetado no 3º arg do construtor (que era ignorado)
- Implementação mínima em: `src/core/streaming-tool-executor.ts` — campo `logger: Logger`, 3º parâmetro opcional no construtor, substituição de `console.warn(...)` por `this.logger.warn(...)`
- Suíte completa: 850 testes verdes (falha pré-existente em `teams-bot/agent-factory.test.ts`)

## Mudanças de regras (justificativa)
Nenhuma. Adição backward-compatible: terceiro argumento do construtor é opcional; callers existentes sem logger continuam funcionando com logger padrão.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014MTyqUA4MxDxefaWz9icFQ)_