### PR TITLE
fix: guarda explícita para choices[] vazio em llm-client.chat() (closes #154)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -133,7 +133,12 @@ export class LLMClient {
       );
     }
 
-    const choice = json.choices[0]!;
+    const choice = json.choices?.[0];
+    if (!choice) {
+      throw new Error(
+        `LLM API returned empty choices (model=${this.model}). Response: ${JSON.stringify(json).slice(0, 200)}`,
+      );
+    }
     const usage: TokenUsage = {
       inputTokens: json.usage?.prompt_tokens ?? 0,
       outputTokens: json.usage?.completion_tokens ?? 0,

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -168,6 +168,37 @@ describe('LLMClient', () => {
       expect(errorMessage).toContain('Model context limit exceeded');
       expect(errorMessage).not.toContain('"error"');
     });
+
+    it('should throw a descriptive error when LLM returns empty choices array (issue #154)', async () => {
+      mockFetch(
+        new Response(
+          JSON.stringify({
+            choices: [],
+            usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      await expect(client.chat({ messages: [{ role: 'user', content: 'Hi' }] })).rejects.toThrow(
+        'LLM API returned empty choices',
+      );
+    });
+
+    it('should throw a descriptive error when LLM response has no choices field (issue #154)', async () => {
+      mockFetch(
+        new Response(
+          JSON.stringify({ usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 } }),
+          {
+            status: 200,
+          },
+        ),
+      );
+
+      await expect(client.chat({ messages: [{ role: 'user', content: 'Hi' }] })).rejects.toThrow(
+        'LLM API returned empty choices',
+      );
+    });
   });
 
   describe('streamChat()', () => {


### PR DESCRIPTION
## Issue
Closes #154

## Problema
`llm-client.ts:136` usava `json.choices[0]!` (non-null assertion TypeScript), que é compile-time apenas. Em runtime, quando o provider retorna `choices: []` ou omite o campo, `choice` fica `undefined` e a linha seguinte lança `TypeError: Cannot read properties of undefined (reading 'message')` — não tratado e sem diagnóstico.

O path de streaming já tratava esse caso corretamente com optional chaining e guarda explícita (`parseSSEStream:295`). Apenas o path `chat()` estava afetado.

## Abordagem TDD
- Teste em: `tests/unit/llm/llm-client.test.ts`
- Falha antes do fix (red): 2 testes novos lançavam `TypeError: Cannot read properties of undefined` em vez de `"LLM API returned empty choices"`
- Implementação mínima em: `src/llm/llm-client.ts` — substituiu `json.choices[0]!` por `json.choices?.[0]` + guarda `if (!choice) throw`
- Suíte completa: verde (873/873; 1 falha pré-existente em `agent-factory.test.ts` não relacionada — requer `pnpm build`)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139i5NHW862SRCEunjmLTPk)_