### PR TITLE
fix: limite de 10 MB no FileWrite para prevenir exaustão de disco (closes #156)

### DIFF
--- a/src/tools/builtin/file-write.ts
+++ b/src/tools/builtin/file-write.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import type { AgentTool } from '../../contracts/entities/agent-tool.js';
 import { assertSafePath } from './path-guard.js';
 
+const MAX_WRITE_SIZE = 10_000_000; // 10 MB
+
 const FileWriteParams = z.object({
   file_path: z.string().describe('Absolute path to the file to write'),
   content: z.string().describe('Content to write to the file'),
@@ -27,6 +29,14 @@ export function createFileWriteTool(workingDir?: string): AgentTool {
         } catch (error) {
           return { content: (error as Error).message, isError: true };
         }
+      }
+
+      const byteSize = Buffer.byteLength(content, 'utf-8');
+      if (byteSize > MAX_WRITE_SIZE) {
+        return {
+          content: `Content exceeds maximum write size (${byteSize} bytes > ${MAX_WRITE_SIZE} bytes limit)`,
+          isError: true,
+        };
       }
 
       try {

--- a/tests/unit/tools/builtin/file-write.test.ts
+++ b/tests/unit/tools/builtin/file-write.test.ts
@@ -110,4 +110,32 @@ describe('builtin/file-write', () => {
     const content = typeof result === 'string' ? result : result.content;
     expect(content).toContain('bytes');
   });
+
+  // --- issue #156: unlimited write size allows disk exhaustion ---
+
+  it('rejects content exceeding MAX_WRITE_SIZE (10 MB) with isError (issue #156)', async () => {
+    const tool = createFileWriteTool(tempDir);
+    const oversized = 'x'.repeat(10_000_001); // 1 byte over the 10 MB limit
+    const result = await tool.execute(
+      { file_path: join(tempDir, 'huge.txt'), content: oversized },
+      signal,
+    );
+    const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+    expect(parsed.isError).toBe(true);
+    expect(parsed.content).toMatch(/exceed|limit|size|large/i);
+  });
+
+  it('accepts content exactly at MAX_WRITE_SIZE (10 MB) (issue #156)', async () => {
+    const tool = createFileWriteTool(tempDir);
+    const exactly = 'x'.repeat(10_000_000);
+    const result = await tool.execute(
+      { file_path: join(tempDir, 'max.txt'), content: exactly },
+      signal,
+    );
+    const content = typeof result === 'string' ? result : result.content;
+    expect(content).toContain('bytes');
+    expect(
+      typeof result === 'string' ? false : (result as { isError?: boolean }).isError,
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Issue
Closes #156

## Problema
`file-write.ts` não impunha nenhum limite no tamanho do conteúdo a ser gravado — `FileRead` já tem `MAX_FILE_SIZE = 1_000_000` (1 MB), mas `FileWrite` aceitava strings de tamanho arbitrário. Em ambientes serverless/contêiner com disco limitado isso pode causar `ENOSPC` e falha de outros processos.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/file-write.test.ts`
- Falha antes do fix (red): teste de rejeição de conteúdo > 10 MB retornava `isError: false` (arquivo era escrito sem restrição)
- Implementação mínima em: `src/tools/builtin/file-write.ts` — adicionou constante `MAX_WRITE_SIZE = 10_000_000` (10 MB) e guarda antes do `writeFile` usando `Buffer.byteLength(content, 'utf-8')`
- Suíte completa: verde (11/11 testes de file-write; 873 total)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139i5NHW862SRCEunjmLTPk)_