### PR TITLE
fix: canonicaliza rootDir em assertSafePath para evitar falso positivo com symlink (closes #157)

### DIFF
--- a/src/tools/builtin/path-guard.ts
+++ b/src/tools/builtin/path-guard.ts
@@ -36,8 +36,9 @@ export function resolveSearchDir(
  * Throws if the resolved path (including symlinks) escapes the root.
  */
 export function assertSafePath(filePath: string, rootDir: string): void {
+  const resolvedRoot = resolveReal(rootDir);
   const abs = resolve(filePath);
-  const rel = relative(rootDir, abs);
+  const rel = relative(resolvedRoot, abs);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(
       `Path traversal blocked: "${filePath}" is outside working directory "${rootDir}"`,
@@ -45,7 +46,7 @@ export function assertSafePath(filePath: string, rootDir: string): void {
   }
   // Resolve symlinks to catch traversal via symlinks inside workDir
   const real = resolveReal(abs);
-  const realRel = relative(rootDir, real);
+  const realRel = relative(resolvedRoot, real);
   if (realRel.startsWith('..') || isAbsolute(realRel)) {
     throw new Error(
       `Path traversal via symlink blocked: "${filePath}" resolves outside working directory "${rootDir}"`,

--- a/tests/unit/tools/builtin/path-guard.test.ts
+++ b/tests/unit/tools/builtin/path-guard.test.ts
@@ -52,4 +52,33 @@ describe('assertSafePath', () => {
       /symlink|traversal|outside/i,
     );
   });
+
+  // --- issue #157: rootDir as symlink causes false positive ---
+
+  it('allows a legitimate file when rootDir is a symlink to the real workDir (issue #157)', async () => {
+    // workDir is the real directory; we create a symlink to it to simulate
+    // a Docker/CI setup where WORKDIR is mounted at a symlinked path.
+    const symlinkToWorkDir = join(outsideDir, 'symlink-to-workdir');
+    await symlink(workDir, symlinkToWorkDir);
+
+    const file = join(workDir, 'legit.txt');
+    await writeFile(file, 'ok');
+
+    // File is legitimate (inside the real dir), but rootDir is a symlink.
+    // Without canonicalization of rootDir this throws a false-positive traversal error.
+    expect(() => assertSafePath(file, symlinkToWorkDir)).not.toThrow();
+  });
+
+  it('still blocks symlink traversal when rootDir itself is a symlink (issue #157)', async () => {
+    // rootDir is a symlink; a symlink INSIDE workDir pointing outside must still be blocked.
+    const symlinkToWorkDir = join(outsideDir, 'symlink-to-workdir');
+    await symlink(workDir, symlinkToWorkDir);
+
+    const evilTarget = join(outsideDir, 'evil.txt');
+    await writeFile(evilTarget, 'evil');
+    const evilLink = join(workDir, 'evil-link.txt');
+    await symlink(evilTarget, evilLink);
+
+    expect(() => assertSafePath(evilLink, symlinkToWorkDir)).toThrow(/symlink|traversal|outside/i);
+  });
 });


### PR DESCRIPTION
## Issue
Closes #157

## Problema
`assertSafePath` em `path-guard.ts` resolvia symlinks do `filePath` via `resolveReal(abs)`, mas usava `rootDir` sem canonicalização. Quando `rootDir` continha um symlink (comum em Docker, CI, ou setups com `WORKDIR` simbólico), a comparação `relative(rootDir, abs)` produzia um falso positivo do tipo `Path traversal blocked` para arquivos legítimos dentro do diretório real.

Exemplo:
- `rootDir = '/tmp/project-link'` (symlink → `/home/user/project`)
- `filePath = '/home/user/project/src/main.ts'` (legítimo)
- `relative('/tmp/project-link', '/home/user/project/src/main.ts')` → `'../../home/user/project/src/main.ts'` → BLOQUEADO erroneamente

**Nota de segurança:** O caso reverso (symlink dentro do workDir apontando para fora) continua corretamente bloqueado pelo check de `realRel`.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/path-guard.test.ts`
- Falha antes do fix (red): `assertSafePath(realFile, symlinkToWorkDir)` lançava `Path traversal blocked` para arquivo legítimo
- Implementação mínima em: `src/tools/builtin/path-guard.ts` — adicionou `const resolvedRoot = resolveReal(rootDir)` e substituiu `rootDir` por `resolvedRoot` nas comparações
- Suíte completa: verde (7/7 testes de path-guard; 873 total)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139i5NHW862SRCEunjmLTPk)_