### PR TITLE
fix: override fast-uri >=3.1.2 (closes #163)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,14 +87,16 @@
     "hono": ">=4.12.16",
     "@hono/node-server": ">=1.19.13",
     "postcss": ">=8.5.10",
-    "ip-address": ">=10.1.1"
+    "ip-address": ">=10.1.1",
+    "fast-uri": ">=3.1.2"
   },
   "pnpm": {
     "overrides": {
       "hono": ">=4.12.16",
       "@hono/node-server": ">=1.19.13",
       "postcss": ">=8.5.10",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "fast-uri": ">=3.1.2"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@hono/node-server': '>=1.19.13'
   postcss: '>=8.5.10'
   ip-address: '>=10.1.1'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -1952,8 +1953,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -4879,7 +4880,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5500,7 +5501,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/tests/unit/package-security.test.ts
+++ b/tests/unit/package-security.test.ts
@@ -96,3 +96,18 @@ describe('release.yml — release-please based, no manual git push to main', () 
     expect(releaseYml).toMatch(/release-please\.outputs\.release_created\s*==\s*'true'/);
   });
 });
+
+describe('pnpm overrides — CVE-2026-6321 + CVE-2026-6322 fast-uri path-traversal & host-confusion (issue #163)', () => {
+  it('pins fast-uri to >=3.1.2 in pnpm.overrides to fix CVE-2026-6321 and CVE-2026-6322', () => {
+    const pnpmSection = pkg.pnpm as { overrides?: Record<string, string> } | undefined;
+    const overrides = pnpmSection?.overrides ?? {};
+    expect(overrides).toHaveProperty('fast-uri');
+    expect(overrides['fast-uri']).toBe('>=3.1.2');
+  });
+
+  it('pins fast-uri to >=3.1.2 in top-level overrides for npm compatibility (issue #163)', () => {
+    const overrides = pkg.overrides as Record<string, string>;
+    expect(overrides).toHaveProperty('fast-uri');
+    expect(overrides['fast-uri']).toBe('>=3.1.2');
+  });
+});


### PR DESCRIPTION
## Issue
Closes #163

## Problema
`fast-uri <= 3.1.1` (transitiva via `@commitlint/cli → ajv → fast-uri`) contém duas CVEs de alta severidade:
- **CVE-2026-6321**: path traversal via dot-segments codificados em `normalize()`/`equal()`
- **CVE-2026-6322**: host confusion via delimitadores codificados (`%40`, `%3A`) no componente `host`

Embora seja devDependency, o lockfile sem override permite que versões vulneráveis permaneçam no ambiente de CI/CD.

## Abordagem TDD
- Teste em: `tests/unit/package-security.test.ts`
- Falha antes do fix (red): `expected { hono: '>=4.12.16', …(3) } to have property "fast-uri"`
- Implementação mínima em: `package.json` (`overrides` e `pnpm.overrides`) + regeneração de `pnpm-lock.yaml`
- Suíte completa: 889 testes verdes

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiTdTKXdQCc7Tr3FdTa2CD)_