### PR TITLE
fix: invalida searchCache após ingest() no KnowledgeManager (closes #170)

### DIFF
--- a/src/knowledge/knowledge-manager.ts
+++ b/src/knowledge/knowledge-manager.ts
@@ -71,6 +71,8 @@ export class KnowledgeManager {
       }
     }
 
+    this.searchCache.clear();
+
     return chunkObjs.length;
   }
 

--- a/tests/unit/knowledge/knowledge-manager.test.ts
+++ b/tests/unit/knowledge/knowledge-manager.test.ts
@@ -71,4 +71,25 @@ describe('KnowledgeManager', () => {
 
     expect(embeddingService.embedSingle).toHaveBeenCalledOnce();
   });
+
+  it('should invalidate search cache after ingest()', async () => {
+    // First search — populates cache
+    vi.mocked(store.search).mockReturnValue([]);
+    await manager.search('query');
+    expect(embeddingService.embedSingle).toHaveBeenCalledOnce();
+
+    // Ingest a new document
+    await manager.ingest({ content: 'New relevant content for the query.' });
+
+    // Now store returns the newly ingested chunk
+    vi.mocked(store.search).mockReturnValue([
+      { id: 'new', content: 'New relevant content', score: 0.9, metadata: {} },
+    ]);
+
+    // Second search — cache must be cleared so store is consulted again
+    const results = await manager.search('query');
+    expect(embeddingService.embedSingle).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe('new');
+  });
 });


### PR DESCRIPTION
## Issue
Closes #170

## Problema
`KnowledgeManager.ingest()` persistia novos chunks no store mas não invalidava o `searchCache` (LRU com TTL de 5 min). Qualquer busca feita antes da ingestão retornava resultado cacheado por até 5 minutos, excluindo os documentos recém-ingeridos.

## Abordagem TDD
- Teste em: `tests/unit/knowledge/knowledge-manager.test.ts` — "should invalidate search cache after ingest()"
- Falha antes do fix (red): `embedSingle` chamado 1x em vez de 2x — segunda busca servia do cache stale
- Implementação mínima em: `src/knowledge/knowledge-manager.ts` — `this.searchCache.clear()` após o upsert
- Suíte completa: verde (890/890 testes passando)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjtMsBawEXX3b8NfKseJ36)_