### PR TITLE
fix: bloqueia symlink path traversal em readMemory/deleteMemory (closes #171)

### DIFF
--- a/src/memory/file-memory-system.ts
+++ b/src/memory/file-memory-system.ts
@@ -35,7 +35,7 @@ import {
   sanitizeFilename,
   sanitizeFrontmatterValue,
   validateThreadId,
-  validateMemoryPath,
+  validateMemoryPathResolved,
 } from './memory-paths.js';
 import { scanMemoryFiles, formatMemoryManifest, parseFrontmatter } from './memory-scanner.js';
 import { selectRelevantMemories } from './memory-relevance.js';
@@ -135,7 +135,7 @@ export class FileMemorySystem {
     try {
       const dir = this.resolveDir(threadId);
       const candidate = join(dir, filename);
-      const filePath = validateMemoryPath(candidate, this.memoryDir);
+      const filePath = await validateMemoryPathResolved(candidate, this.memoryDir);
       if (!filePath) return null;
       const content = await readFile(filePath, 'utf-8');
       const fileStat = await stat(filePath);
@@ -166,7 +166,7 @@ export class FileMemorySystem {
     try {
       const dir = this.resolveDir(threadId);
       const candidate = join(dir, filename);
-      const filePath = validateMemoryPath(candidate, this.memoryDir);
+      const filePath = await validateMemoryPathResolved(candidate, this.memoryDir);
       if (!filePath) return false;
       await unlink(filePath);
       await this.removeFromIndex(filename, threadId);

--- a/tests/unit/memory/file-memory-system.test.ts
+++ b/tests/unit/memory/file-memory-system.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, readFile, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -369,6 +369,52 @@ describe('FileMemorySystem — concurrent writes (withWriteLock)', () => {
     for (let i = 0; i < 5; i++) {
       expect(index).toContain(`mem-${i}.md`);
     }
+  });
+});
+
+describe('FileMemorySystem — symlink path traversal in readMemory/deleteMemory (#171)', () => {
+  let tempDir: string;
+  let outsideDir: string;
+  let system: FileMemorySystem;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'fms-sym-'));
+    outsideDir = await mkdtemp(join(tmpdir(), 'fms-outside-'));
+    const client = createMockClient();
+    const logger = createMockLogger();
+    system = new FileMemorySystem({ memoryDir: tempDir }, client, logger);
+    await system.ensureDir();
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it('readMemory — rejects symlink pointing outside memory dir', async () => {
+    const victimPath = join(outsideDir, 'secret.md');
+    await writeFile(victimPath, 'sensitive content', 'utf-8');
+
+    // Create symlink inside memory dir pointing to victim outside
+    await symlink(victimPath, join(tempDir, 'evil.md'));
+
+    // Should be blocked — symlink escapes memory dir
+    const result = await system.readMemory('evil.md');
+    expect(result).toBeNull();
+  });
+
+  it('deleteMemory — rejects symlink pointing outside memory dir', async () => {
+    const victimPath = join(outsideDir, 'target.md');
+    await writeFile(victimPath, 'do not delete', 'utf-8');
+
+    await symlink(victimPath, join(tempDir, 'evil.md'));
+
+    const deleted = await system.deleteMemory('evil.md');
+    expect(deleted).toBe(false);
+
+    // Confirm victim file was NOT deleted
+    const content = await readFile(victimPath, 'utf-8');
+    expect(content).toBe('do not delete');
   });
 });
 


### PR DESCRIPTION
## Issue
Closes #171

## Problema
`readMemory()` e `deleteMemory()` usavam `validateMemoryPath()` (checagem baseada em string) que não resolve symlinks. Um atacante com acesso de escrita ao diretório de memória poderia criar um symlink apontando para um arquivo fora do diretório, e a leitura seguiria o symlink — expondo o conteúdo ao contexto do LLM.

## Abordagem TDD
- Testes em: `tests/unit/memory/file-memory-system.test.ts` — bloco "symlink path traversal in readMemory/deleteMemory (#171)"
- Falha antes do fix (red): `readMemory('evil.md')` seguia symlink externo e retornava conteúdo; `deleteMemory('evil.md')` apagava o arquivo alvo
- Implementação mínima em: `src/memory/file-memory-system.ts` — substituída `validateMemoryPath` por `validateMemoryPathResolved` (já existia em `memory-paths.ts`) nos métodos `readMemory` e `deleteMemory`
- Suíte completa: verde (891/891 testes passando)

## Mudanças de regras (justificativa)
Nenhuma. `validateMemoryPathResolved` já estava definida e exportada em `memory-paths.ts` — apenas não era usada nas operações de leitura/deleção.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjtMsBawEXX3b8NfKseJ36)_