### PR TITLE
fix: guard em LLMClient.embed() para json.data ausente/inválido (closes #172)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -178,6 +178,13 @@ export class LLMClient {
       );
     }
 
+    if (!json.data || !Array.isArray(json.data)) {
+      throw new Error(
+        `LLM embed API returned unexpected response (model=${model ?? this.model}). ` +
+          `Response: ${JSON.stringify(json).slice(0, 200)}`,
+      );
+    }
+
     return json.data.map((d) => d.embedding);
   }
 

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -341,6 +341,23 @@ describe('LLMClient', () => {
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual([0.1, 0.2, 0.3]);
     });
+
+    it('embed() throws informative error when json.data is missing (#172)', async () => {
+      // Simulate provider returning error body with status 200 (OpenRouter edge case)
+      mockFetch(
+        new Response(JSON.stringify({ error: { message: 'rate limit exceeded' } }), {
+          status: 200,
+        }),
+      );
+
+      await expect(client.embed(['hello'])).rejects.toThrow(/unexpected response/i);
+    });
+
+    it('embed() throws informative error when json.data is not an array (#172)', async () => {
+      mockFetch(new Response(JSON.stringify({ data: null }), { status: 200 }));
+
+      await expect(client.embed(['hello'])).rejects.toThrow(/unexpected response/i);
+    });
   });
 
   describe('resilience', () => {


### PR DESCRIPTION
## Issue
Closes #172

## Problema
`LLMClient.embed()` acessava `json.data.map(...)` sem verificar que `json.data` existia e era um array. Providers como OpenRouter podem retornar `{ "error": {...} }` com status 200 em edge cases de rate limit, causando `TypeError: Cannot read properties of undefined (reading 'map')` — sem contexto sobre o provider, modelo ou resposta real.

## Abordagem TDD
- Testes em: `tests/unit/llm/llm-client.test.ts` — bloco `embed()`, testes "#172"
- Falha antes do fix (red): lançava `TypeError` genérico em vez de mensagem informativa
- Implementação mínima em: `src/llm/llm-client.ts` — guard `if (!json.data || !Array.isArray(json.data))` idêntico ao padrão já usado em `chat()` para `json.choices`
- Suíte completa: verde (891/891 testes passando)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjtMsBawEXX3b8NfKseJ36)_