### PR TITLE
fix: valida comprimento de embeddings antes do map em KnowledgeManager.ingest() (closes #174)

### DIFF
--- a/src/knowledge/knowledge-manager.ts
+++ b/src/knowledge/knowledge-manager.ts
@@ -52,6 +52,16 @@ export class KnowledgeManager {
     if (chunks.length === 0) return 0;
 
     const embeddings = await this.embeddingService.embed(chunks);
+
+    if (embeddings.length !== chunks.length) {
+      const sid = document.metadata?.sourceId;
+      const sourceId = typeof sid === 'string' ? sid : 'unknown';
+      throw new Error(
+        `EmbeddingService returned ${embeddings.length} embeddings for ${chunks.length} chunks` +
+          ` (document: ${sourceId})`,
+      );
+    }
+
     const now = Date.now();
     const chunkObjs: KnowledgeChunk[] = chunks.map((content, i) => ({
       id: randomUUID(),

--- a/tests/unit/knowledge/knowledge-manager.test.ts
+++ b/tests/unit/knowledge/knowledge-manager.test.ts
@@ -71,4 +71,16 @@ describe('KnowledgeManager', () => {
 
     expect(embeddingService.embedSingle).toHaveBeenCalledOnce();
   });
+
+  it('throws informative error when EmbeddingService returns fewer vectors than chunks (#174)', async () => {
+    // Simulate buggy/truncated provider: only 1 embedding returned for multiple chunks
+    vi.mocked(embeddingService.embed).mockResolvedValueOnce([[0.1, 0.2, 0.3]]);
+
+    await expect(
+      manager.ingest({
+        content:
+          'First chunk content here with enough text. Second chunk content here with enough text.',
+      }),
+    ).rejects.toThrow(/embeddingservice returned/i);
+  });
 });

--- a/tests/unit/knowledge/knowledge-manager.test.ts
+++ b/tests/unit/knowledge/knowledge-manager.test.ts
@@ -82,6 +82,8 @@ describe('KnowledgeManager', () => {
           'First chunk content here with enough text. Second chunk content here with enough text.',
       }),
     ).rejects.toThrow(/embeddingservice returned/i);
+  });
+
   it('should invalidate search cache after ingest()', async () => {
     // First search — populates cache
     vi.mocked(store.search).mockReturnValue([]);


### PR DESCRIPTION
## Issue
Closes #174

## Problema
`KnowledgeManager.ingest()` usava `embeddings[i]!` (non-null assertion TypeScript) sem validar que `embeddings.length === chunks.length`. Em JavaScript, `new Float32Array(undefined)` cria silenciosamente um Float32Array vazio (length 0) em vez de lançar um erro. Portanto, se o `EmbeddingService` retornasse menos vetores do que chunks, a ingestão continuava sem erro mas com embeddings incorretos (tamanho 0), corrompendo o knowledge store silenciosamente.

## Abordagem TDD
- Teste em: `tests/unit/knowledge/knowledge-manager.test.ts` — "throws informative error when EmbeddingService returns fewer vectors than chunks (#174)"
- Falha antes do fix (red): a promise resolveu com valor `2` em vez de rejeitar — ingestão completou silenciosamente com embedding corrompido
- Implementação mínima em: `src/knowledge/knowledge-manager.ts` — guard `if (embeddings.length !== chunks.length)` após a chamada ao `embed()`, lançando erro informativo com contagens e sourceId
- Suíte completa: verde (890/890 testes passando)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjtMsBawEXX3b8NfKseJ36)_