### PR TITLE
fix: SSRF guard bloqueia prefixo NAT64 64:ff9b::/96 (closes #190)

### DIFF
--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -68,5 +68,25 @@ export function validateSsrfUrl(rawUrl: string): string | null {
     if (embeddedResult) return `Blocked IPv4-mapped IPv6 (compact form): ${embeddedResult}`;
   }
 
+  // NAT64: 64:ff9b::/96 (RFC 6146) — translates IPv4 addresses to IPv6 on NAT64 networks.
+  // Dot-decimal form: 64:ff9b::a.b.c.d
+  const nat64Dot = /^64:ff9b::(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(ipv6Bare);
+  if (nat64Dot) {
+    const embeddedResult = validateSsrfUrl(`http://${nat64Dot[1]}/`);
+    if (embeddedResult) return `Blocked NAT64 address: ${embeddedResult}`;
+  }
+  // Compact hex form: 64:ff9b::HHHH:HHHH (Node.js URL parser canonicalises dot-decimal to this)
+  const nat64Hex = /^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(ipv6Bare);
+  if (nat64Hex) {
+    const high = parseInt(nat64Hex[1]!, 16);
+    const low = parseInt(nat64Hex[2]!, 16);
+    const a = (high >> 8) & 0xff;
+    const b = high & 0xff;
+    const c = (low >> 8) & 0xff;
+    const d = low & 0xff;
+    const embeddedResult = validateSsrfUrl(`http://${a}.${b}.${c}.${d}/`);
+    if (embeddedResult) return `Blocked NAT64 address (compact form): ${embeddedResult}`;
+  }
+
   return null;
 }

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -65,4 +65,39 @@ describe('validateSsrfUrl', () => {
       expect(validateSsrfUrl('http://100.128.0.0/')).toBeNull();
     });
   });
+
+  // issue #190 — NAT64 prefix 64:ff9b::/96 (RFC 6146) not blocked
+  describe('NAT64 64:ff9b::/96 (issue #190)', () => {
+    it('blocks NAT64 with embedded private 10.0.0.1 (dot-decimal form)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::10.0.0.1]/')).not.toBeNull();
+    });
+
+    it('blocks NAT64 with embedded private 192.168.1.1 (dot-decimal form)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::192.168.1.1]/')).not.toBeNull();
+    });
+
+    it('blocks NAT64 with embedded loopback 127.0.0.1 (dot-decimal form)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::127.0.0.1]/')).not.toBeNull();
+    });
+
+    it('blocks NAT64 with embedded link-local 169.254.0.1 (dot-decimal form)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::169.254.0.1]/')).not.toBeNull();
+    });
+
+    it('blocks NAT64 with embedded 172.16.0.1 (compact hex form ac10:1)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::ac10:1]/')).not.toBeNull();
+    });
+
+    it('blocks NAT64 with embedded 10.0.0.1 (compact hex form a00:1)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::a00:1]/')).not.toBeNull();
+    });
+
+    it('allows NAT64 with embedded public IP 1.1.1.1 (dot-decimal form)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::1.1.1.1]/')).toBeNull();
+    });
+
+    it('allows NAT64 with embedded public IP 8.8.8.8 (compact hex form 808:808)', () => {
+      expect(validateSsrfUrl('http://[64:ff9b::808:808]/')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #190

## Problema
`validateSsrfUrl()` bloqueava corretamente IPv4-mapeados (`::ffff:`) mas não verificava o prefixo NAT64 `64:ff9b::/96` (RFC 6146). Em redes com NAT64 habilitado (comum em GKE/EKS/AKS IPv6-only), endereços como `[64:ff9b::10.0.0.1]` resolvem para IPs IPv4 privados, permitindo SSRF contra endereços internos.

## Abordagem TDD
- Teste em: `tests/unit/utils/ssrf-guard.test.ts`
- Falha antes do fix (red): 6 testes esperavam `not.toBeNull()` para endereços NAT64 com IPs privados embutidos — todos retornavam `null` (passavam sem bloqueio)
- Implementação mínima em: `src/utils/ssrf-guard.ts` — adicionadas duas verificações após os checks IPv4-mapped existentes:
  1. Dot-decimal (`64:ff9b::a.b.c.d`) — re-valida o IPv4 embutido recursivamente
  2. Hex compacto (`64:ff9b::HHHH:HHHH`) — decodifica os octetos e re-valida
- Suíte completa: 897 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. Adição aditiva ao guard existente, sem alterar contratos públicos.

## Checklist
- [x] Teste antes do fix (RED confirmado — 6 falhas `expected null not to be null`)
- [x] Suíte verde (897/897, exceto teams-bot pré-existente)
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_0189NUTUQ2sDq7kkX6crWbLG)_