### PR TITLE
fix: SQLiteDatabase atribui _db apenas após migração bem-sucedida (closes #218)

### DIFF
--- a/src/storage/sqlite-database.ts
+++ b/src/storage/sqlite-database.ts
@@ -27,13 +27,19 @@ export class SQLiteDatabase {
       mkdirSync(dirname(this.path), { recursive: true });
     }
 
-    this._db = new Database(this.path);
+    const db = new Database(this.path);
 
     // Enable WAL mode for concurrent reads
-    this._db.pragma('journal_mode = WAL');
-    this._db.pragma('synchronous = NORMAL');
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
 
-    this.migrateV1();
+    try {
+      this.migrateV1(db);
+      this._db = db;
+    } catch (err) {
+      db.close();
+      throw err;
+    }
   }
 
   close(): void {
@@ -43,9 +49,7 @@ export class SQLiteDatabase {
     }
   }
 
-  private migrateV1(): void {
-    const db = this.db;
-
+  private migrateV1(db: BetterSqlite3.Database): void {
     db.exec(`
       CREATE TABLE IF NOT EXISTS memories (
         id TEXT PRIMARY KEY,

--- a/tests/unit/storage/sqlite-database.test.ts
+++ b/tests/unit/storage/sqlite-database.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { SQLiteDatabase } from '../../../src/storage/sqlite-database.js';
 
 describe('SQLiteDatabase', () => {
@@ -69,6 +69,30 @@ describe('SQLiteDatabase', () => {
     db = new SQLiteDatabase(':memory:');
     db.initialize();
     db.initialize(); // should not throw
+  });
+
+  it('leaves _db null when migration throws so reinitialize can recover (#218)', () => {
+    db = new SQLiteDatabase(':memory:');
+
+    // Force the private migration method to throw on first call
+    vi.spyOn(db as unknown as Record<string, () => void>, 'migrateV1').mockImplementationOnce(
+      () => {
+        throw new Error('Simulated migration failure');
+      },
+    );
+
+    expect(() => db.initialize()).toThrow('Simulated migration failure');
+
+    // Bug: with the old code _db is already set, so db.db would NOT throw here.
+    // After the fix, _db must remain null after a failed migration.
+    expect(() => db.db).toThrow('not initialized');
+
+    // A second initialize() attempt must succeed now that the spy is restored.
+    expect(() => db.initialize()).not.toThrow();
+    const tables = db.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all() as { name: string }[];
+    expect(tables.map((t) => t.name)).toContain('conversations');
   });
 
   it('should close cleanly', () => {


### PR DESCRIPTION
## Issue
Closes #218

## Problema
Em `initialize()`, `this._db` era atribuído na linha 30 **antes** de `migrateV1()` ser chamada. Se a migração lançasse exceção, `_db` permanecia definido apontando para um banco sem tabelas. Chamadas subsequentes a `initialize()` retornavam imediatamente pelo guard `if (this._db) return`, deixando o banco inutilizável de forma silenciosa.

## Abordagem TDD
- Teste em: `tests/unit/storage/sqlite-database.test.ts`
- Falha antes do fix (red): `_db` já estava definido após migração falhar → `expect(() => db.db).toThrow('not initialized')` falhava
- Implementação mínima em: `src/storage/sqlite-database.ts`
  - Cria instância local `db`, executa `migrateV1(db)`, só atribui `this._db = db` em caso de sucesso
  - Em caso de falha: fecha `db` e re-lança o erro
  - `migrateV1` agora recebe o `db` como parâmetro em vez de acessar `this.db`
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_