### PR TITLE
fix: rastrear e abortar forks em background ao destruir Agent (closes #219)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -66,6 +66,8 @@ export class Agent {
   private lastEmittedDate?: string;
   /** Turn-end hooks — run after each completed assistant turn. */
   private readonly turnEndHooks: TurnEndHook[] = [];
+  /** AbortControllers for background forks — aborted in destroy(). */
+  private readonly backgroundForks = new Set<AbortController>();
 
   private constructor(config: AgentConfig) {
     this.config = config;
@@ -570,7 +572,7 @@ export class Agent {
   ): Promise<string> {
     if (this.destroyed) throw new Error('Agent is destroyed');
 
-    const run = async () => {
+    const run = async (signal?: AbortSignal) => {
       const child = Agent.create({
         apiKey: this.config.apiKey,
         model: options?.model ?? this.config.model,
@@ -591,16 +593,24 @@ export class Agent {
       }
 
       try {
-        return await child.chat(prompt);
+        return await child.chat(prompt, signal ? { signal } : undefined);
       } finally {
         await child.destroy();
       }
     };
 
     if (options?.background) {
-      void run().catch((err) => {
-        this.logger.debug('Background fork failed', { error: String(err) });
-      });
+      const ctrl = new AbortController();
+      this.backgroundForks.add(ctrl);
+      void run(ctrl.signal)
+        .catch((err) => {
+          if ((err as { name?: string }).name !== 'AbortError') {
+            this.logger.debug('Background fork failed', { error: String(err) });
+          }
+        })
+        .finally(() => {
+          this.backgroundForks.delete(ctrl);
+        });
       return ''; // fire-and-forget — returns immediately
     }
 
@@ -704,6 +714,8 @@ export class Agent {
 
   async destroy(): Promise<void> {
     this.destroyed = true;
+    for (const ctrl of this.backgroundForks) ctrl.abort();
+    this.backgroundForks.clear();
     this.skillManager?.clearAllStickySessions();
     this.skillManager?.clearInvokedSkills();
     this.surfacedMemories.clear();

--- a/tests/unit/agent-fork.test.ts
+++ b/tests/unit/agent-fork.test.ts
@@ -122,4 +122,36 @@ describe('Agent.fork()', () => {
 
     await expect(agent.fork('test')).rejects.toThrow('destroyed');
   });
+
+  it('destroy() aborts in-flight background forks (#219)', async () => {
+    let forkSignal: AbortSignal | undefined;
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_url, init) =>
+        new Promise((_res, rej) => {
+          forkSignal = init?.signal ?? undefined;
+          init?.signal?.addEventListener('abort', () =>
+            rej(new DOMException('Aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    const agent = Agent.create({
+      apiKey: 'test-key',
+      memory: { enabled: false },
+      knowledge: { enabled: false },
+    });
+
+    // Start a background fork that will never complete on its own
+    void agent.fork('hang forever', { background: true });
+
+    // Wait for the fork to start and reach the fetch mock
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Destroy parent — the fix must abort background forks
+    await agent.destroy();
+
+    // The abort signal injected by the fix must be triggered after destroy()
+    expect(forkSignal?.aborted).toBe(true);
+  });
 });


### PR DESCRIPTION
## Issue
Closes #219

## Problema
`fork()` com `background: true` disparava um agente filho sem rastreamento — `destroy()` no pai não tinha como cancelar essas operações. Filhos continuavam fazendo chamadas à API LLM indefinidamente após o pai ser destruído (consumindo tokens, vazando recursos em testes).

## Abordagem TDD
- Teste em: `tests/unit/agent-fork.test.ts`
- Falha antes do fix (red): `forkSignal?.aborted` retornava `false` após `destroy()`
- Implementação mínima em: `src/agent.ts`
  - Novo campo `private readonly backgroundForks = new Set<AbortController>()`
  - `run()` aceita `signal?: AbortSignal` e passa para `child.chat()`
  - Branch `background: true` cria `AbortController`, adiciona ao set, remove no `finally`
  - `destroy()` aborta todos os controllers antes do cleanup existente
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_