### PR TITLE
fix: validar comando MCP stdio contra allowedStdioCommands (closes #212)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,6 +8,8 @@ const MCPConnectionConfigSchema = z.object({
   transport: z.enum(['stdio', 'sse', 'http', 'auto']),
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
+  /** Optional allowlist for stdio commands. When set, only listed commands are permitted. */
+  allowedStdioCommands: z.array(z.string()).optional(),
   url: z.string().url().optional(),
   headers: z.record(z.string()).optional(),
   timeout: z.number().positive().default(30_000),

--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -605,6 +605,14 @@ async function createTransport(config: MCPConnectionConfig): Promise<unknown> {
     if (!config.command) {
       throw new Error('MCPConnectionConfig: "command" is required for transport "stdio"');
     }
+    if (
+      config.allowedStdioCommands !== undefined &&
+      !config.allowedStdioCommands.includes(config.command)
+    ) {
+      throw new Error(
+        `MCP stdio command "${config.command}" is not in allowedStdioCommands: [${config.allowedStdioCommands.join(', ')}]`,
+      );
+    }
     const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
     return new StdioClientTransport({ command: config.command, args: config.args ?? [] });
   }

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -173,6 +173,31 @@ describe('MCPAdapter', () => {
           adapter.connect({ name: 'no-url-auto', transport: 'auto' } as never),
         ).rejects.toThrow(/"url".*auto|auto.*"url"/i);
       });
+
+      // issue #212 — stdio command not in allowedStdioCommands must be rejected
+      it('throws when stdio command is not in allowedStdioCommands (#212)', async () => {
+        await expect(
+          adapter.connect({
+            name: 'blocked-cmd',
+            transport: 'stdio',
+            command: 'bash',
+            allowedStdioCommands: ['npx', 'node'],
+          }),
+        ).rejects.toThrow(/allowedStdioCommands|not allowed|blocked/i);
+      });
+
+      it('allows stdio command when it is in allowedStdioCommands (#212)', async () => {
+        await expect(
+          adapter.connect({
+            name: 'allowed-cmd',
+            transport: 'stdio',
+            command: 'npx',
+            allowedStdioCommands: ['npx', 'node'],
+          }),
+        ).resolves.not.toThrow();
+
+        await adapter.disconnect('allowed-cmd');
+      });
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #212

## Problema
`createTransport` passava `config.command` diretamente para `StdioClientTransport` sem nenhuma validação — qualquer string era aceita, incluindo `bash -c "..."`. Em aplicações multi-tenant ou que expõem a configuração de MCP via UI, isso permite execução de comandos OS arbitrários.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts`
- Falha antes do fix (red): `command: 'bash'` com `allowedStdioCommands: ['npx', 'node']` não lançava erro
- Implementação mínima em: `src/config/config.ts` e `src/tools/mcp-adapter.ts`
  - Campo opcional `allowedStdioCommands: z.array(z.string()).optional()` no schema
  - Guard em `createTransport`: se `allowedStdioCommands` está definido e `command` não está na lista, lança erro descritivo
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma — `allowedStdioCommands` é opt-in; configs existentes sem esse campo continuam funcionando.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_