### PR TITLE
fix: isolar estado por thread em stream() — elimina race condition (closes #220)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -58,10 +58,11 @@ export class Agent {
   private readonly mcpAdapter: MCPAdapter;
   private database?: SQLiteDatabase;
   private costAccumulator: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
-  private turnsSinceExtraction = 0;
+  /** Per-thread turn count for memory extraction scheduling. */
+  private readonly turnsSinceExtractionByThread = new Map<string, number>();
   private destroyed = false;
-  /** Filenames already injected in this session — avoids re-surfacing the same memory. */
-  private surfacedMemories = new Set<string>();
+  /** Per-thread filenames already injected — avoids re-surfacing the same memory per thread. */
+  private readonly surfacedMemoriesByThread = new Map<string, Set<string>>();
   /** Last date emitted to model — for midnight change detection. */
   private lastEmittedDate?: string;
   /** Turn-end hooks — run after each completed assistant turn. */
@@ -449,17 +450,19 @@ export class Agent {
       usage: terminal.usage,
     };
 
-    // Built-in: memory extraction hook
-    this.turnsSinceExtraction++;
+    // Built-in: memory extraction hook (counter is per-thread to avoid cross-thread interference)
+    const prevTurns = this.turnsSinceExtractionByThread.get(threadId) ?? 0;
+    const nextTurns = prevTurns + 1;
+    this.turnsSinceExtractionByThread.set(threadId, nextTurns);
     if (
       this.fileMemorySystem &&
       this.config.memory?.extractionEnabled !== false &&
-      shouldExtract(userContent, this.turnsSinceExtraction, {
+      shouldExtract(userContent, nextTurns, {
         samplingRate: this.config.memory?.samplingRate,
         extractionInterval: this.config.memory?.extractionInterval,
       })
     ) {
-      this.turnsSinceExtraction = 0;
+      this.turnsSinceExtractionByThread.set(threadId, 0);
       const memSystem = this.fileMemorySystem;
       const logger = this.logger;
       const conversations = this.conversations;
@@ -620,8 +623,9 @@ export class Agent {
     const tid = threadId ?? 'default';
     this.conversations.clearThread(tid);
     this.skillManager?.clearStickySkills(tid);
-    // Prevent unbounded growth of the surfaced-memory set across long sessions.
-    this.surfacedMemories.clear();
+    // Clear per-thread state to prevent unbounded growth across long sessions.
+    this.surfacedMemoriesByThread.delete(tid);
+    this.turnsSinceExtractionByThread.delete(tid);
     this.logger.info('Thread cleared', { threadId: tid });
   }
 
@@ -706,7 +710,8 @@ export class Agent {
     this.destroyed = true;
     this.skillManager?.clearAllStickySessions();
     this.skillManager?.clearInvokedSkills();
-    this.surfacedMemories.clear();
+    this.surfacedMemoriesByThread.clear();
+    this.turnsSinceExtractionByThread.clear();
     await this.mcpAdapter.disconnectAll();
     this.database?.close();
     this.logger.info('Agent destroyed');
@@ -746,12 +751,9 @@ export class Agent {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), Agent.MEMORY_PREFETCH_TIMEOUT);
 
-    return this.fileMemorySystem!.findRelevant(
-      userInput,
-      controller.signal,
-      this.surfacedMemories,
-      threadId,
-    )
+    const tid = threadId ?? 'default';
+    const surfaced = this.surfacedMemoriesByThread.get(tid) ?? new Set<string>();
+    return this.fileMemorySystem!.findRelevant(userInput, controller.signal, surfaced, threadId)
       .catch(() => [] as MemoryFile[])
       .finally(() => clearTimeout(timeout));
   }
@@ -890,9 +892,13 @@ export class Agent {
             tokens,
           });
 
-          // Track surfaced filenames to avoid re-injection in subsequent turns
+          // Track surfaced filenames per-thread to avoid re-injection in subsequent turns
+          if (!this.surfacedMemoriesByThread.has(threadId)) {
+            this.surfacedMemoriesByThread.set(threadId, new Set<string>());
+          }
+          const threadSurfaced = this.surfacedMemoriesByThread.get(threadId)!;
           for (const m of relevant) {
-            this.surfacedMemories.add(m.filename);
+            threadSurfaced.add(m.filename);
           }
         }
       } catch {

--- a/tests/unit/agent-coverage.test.ts
+++ b/tests/unit/agent-coverage.test.ts
@@ -344,6 +344,55 @@ describe('Agent — additional coverage', () => {
   // loadSkillsDir()
   // ---------------------------------------------------------------------------
 
+  // ---------------------------------------------------------------------------
+  // Per-thread state isolation (#220)
+  // ---------------------------------------------------------------------------
+
+  it('turnsSinceExtraction is tracked per-thread, not globally (#220)', async () => {
+    const sseData = [
+      'data: {"choices":[{"delta":{"content":"ok"},"index":0}]}\n\n',
+      'data: {"choices":[{"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}\n\n',
+    ].join('');
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/embeddings')) {
+        return new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), { status: 200 });
+      }
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    });
+
+    const agent = Agent.create({
+      apiKey: 'test-key',
+      memory: { enabled: false },
+      knowledge: { enabled: false },
+    });
+
+    // Two turns on thread-a, one turn on thread-b
+    await agent.chat('hello', { threadId: 'thread-a' });
+    await agent.chat('world', { threadId: 'thread-a' });
+    await agent.chat('hi', { threadId: 'thread-b' });
+
+    // With per-thread tracking, each thread's counter must be independent
+    const raw = agent as unknown as Record<string, unknown>;
+    const byThread = raw.turnsSinceExtractionByThread as Map<string, number>;
+
+    // After the fix, the Map must exist and hold per-thread counts
+    expect(byThread).toBeInstanceOf(Map);
+    expect(byThread.get('thread-a')).toBe(2);
+    expect(byThread.get('thread-b')).toBe(1);
+
+    await agent.destroy();
+  });
+
   it('loadSkillsDir() returns the count reported by the skill manager', async () => {
     const { SkillManager } = await import('../../src/skills/skill-manager.js');
     const loadSpy = vi.spyOn(SkillManager.prototype, 'loadFromDirectory').mockResolvedValue(3);


### PR DESCRIPTION
## Issue
Closes #220

## Problema
`turnsSinceExtraction` (número) e `surfacedMemories` (Set) eram campos de instância compartilhados por todas as chamadas a `stream()`. Em bots multi-usuário com um `Agent` compartilhado, chamadas concorrentes com `threadId`s diferentes contaminavam esses contadores mutuamente: memórias de um thread vazavam para o outro, e o gatilho de extração disparava no timing errado.

## Abordagem TDD
- Teste em: `tests/unit/agent-coverage.test.ts`
- Falha antes do fix (red): `(agent as any).turnsSinceExtractionByThread` não existia → `expect(byThread).toBeInstanceOf(Map)` falhava
- Implementação mínima em: `src/agent.ts`
  - `turnsSinceExtraction: number` → `turnsSinceExtractionByThread: Map<string, number>`
  - `surfacedMemories: Set<string>` → `surfacedMemoriesByThread: Map<string, Set<string>>`
  - `clearHistory(tid)` limpa apenas o state do thread especificado
  - `destroy()` limpa ambos os Maps completos
  - `startMemoryPrefetch` e `buildInjectionsWithSkills` usam o Set do thread correto
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_