### PR TITLE
fix: validar contagem de embeddings retornados pelo provider (closes #221)

### DIFF
--- a/src/knowledge/embedding-service.ts
+++ b/src/knowledge/embedding-service.ts
@@ -34,14 +34,24 @@ export class EmbeddingService {
 
     // Fetch uncached
     if (uncached.length > 0) {
-      const embeddings = await this.client.embed(
-        uncached.map((u) => u.text),
-        this.model,
-      );
+      const uncachedTexts = uncached.map((u) => u.text);
+      const embeddings = await this.client.embed(uncachedTexts, this.model);
+
+      if (embeddings.length !== uncached.length) {
+        throw new Error(
+          `EmbeddingService: provider returned ${embeddings.length} embeddings ` +
+            `but ${uncached.length} were requested (model=${this.model})`,
+        );
+      }
+
       for (let i = 0; i < uncached.length; i++) {
         const entry = uncached[i]!;
-        results[entry.index] = embeddings[i]!;
-        this.cache.set(entry.text, embeddings[i]!);
+        const embedding = embeddings[i];
+        if (!embedding) {
+          throw new Error(`EmbeddingService: missing embedding at index ${i}`);
+        }
+        results[entry.index] = embedding;
+        this.cache.set(entry.text, embedding);
       }
     }
 

--- a/tests/unit/knowledge/embedding-service.test.ts
+++ b/tests/unit/knowledge/embedding-service.test.ts
@@ -47,6 +47,7 @@ describe('EmbeddingService', () => {
 
     it('should pass custom model to client.embed', async () => {
       const svc = new EmbeddingService(client, { model: 'custom-model' });
+      vi.mocked(client.embed).mockResolvedValueOnce([[0.1, 0.2]]);
       await svc.embed(['test']);
 
       expect(client.embed).toHaveBeenCalledWith(['test'], 'custom-model');
@@ -92,6 +93,30 @@ describe('EmbeddingService', () => {
 
       expect(client.embed).toHaveBeenCalledWith(['single'], undefined);
       expect(results).toEqual([[0.5, 0.6, 0.7]]);
+    });
+  });
+
+  describe('embed() count validation (#221)', () => {
+    it('throws when provider returns fewer embeddings than requested', async () => {
+      // Provider returns only 1 embedding for 3 texts
+      vi.mocked(client.embed).mockResolvedValueOnce([[0.1, 0.2]]);
+
+      await expect(service.embed(['text-a', 'text-b', 'text-c'])).rejects.toThrow(
+        /EmbeddingService.*provider returned 1.*3 were requested|count mismatch/i,
+      );
+    });
+
+    it('throws when provider returns more embeddings than requested', async () => {
+      // Provider returns 3 embeddings for 2 texts
+      vi.mocked(client.embed).mockResolvedValueOnce([
+        [0.1, 0.2],
+        [0.3, 0.4],
+        [0.5, 0.6],
+      ]);
+
+      await expect(service.embed(['text-a', 'text-b'])).rejects.toThrow(
+        /EmbeddingService.*provider returned 3.*2 were requested|count mismatch/i,
+      );
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #221

## Problema
Em `embed()`, os embeddings retornados pela API eram mapeados por índice com o operador `!` (non-null assertion), sem verificar se a quantidade retornada batia com a enviada. Se um provider retornasse menos embeddings, `embeddings[i]` seria `undefined`, levando a falhas silenciosas em buscas semânticas (similaridade de cosseno `NaN`) ou `TypeError` ao criar `Float32Array`.

## Abordagem TDD
- Teste em: `tests/unit/knowledge/embedding-service.test.ts`
- Falha antes do fix (red): embed com 3 textos e mock retornando 1 embedding não lançava erro
- Implementação mínima em: `src/knowledge/embedding-service.ts`
  - Após receber os embeddings, valida `embeddings.length !== uncached.length` e lança erro descritivo
  - Remove operador `!` e adiciona guard explícito por índice
- Suíte completa: verde (1 test mock existente corrigido para retornar contagem correta)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_