### PR TITLE
fix(memory-paths): reject dangling symlinks in validateMemoryPathResolved (#215)

### DIFF
--- a/src/memory/memory-paths.ts
+++ b/src/memory/memory-paths.ts
@@ -9,7 +9,7 @@
 
 import { homedir } from 'node:os';
 import { isAbsolute, join, normalize, sep } from 'node:path';
-import { mkdir, realpath } from 'node:fs/promises';
+import { lstat, mkdir, realpath } from 'node:fs/promises';
 
 /**
  * Default memory directory: `<cwd>/.agentx/memory/`.
@@ -122,6 +122,21 @@ export async function validateMemoryPathResolved(
 ): Promise<string | undefined> {
   const cheap = validateMemoryPath(path, memoryDir);
   if (!cheap) return undefined;
+
+  // lstat does not follow symlinks — it succeeds even for dangling symlinks.
+  // Use it to distinguish "entry exists (possibly dangling)" from "no entry".
+  try {
+    await lstat(cheap);
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+      // File genuinely doesn't exist — safe to use cheap path for creates.
+      return cheap;
+    }
+    return undefined;
+  }
+
+  // Entry exists on disk; resolve and validate the real path.
+  // If realpath throws here (e.g. dangling symlink, ELOOP), reject.
   try {
     const real = await realpath(cheap);
     const realDir = await realpath(normalize(memoryDir).replace(/[/\\]+$/, ''));
@@ -129,10 +144,7 @@ export async function validateMemoryPathResolved(
     if (real !== realDir && !real.startsWith(realDirWithSep)) return undefined;
     return real;
   } catch {
-    // realpath fails when the target doesn't exist yet — that's normal for
-    // creates. Fall back to the cheap (string) check, which still guards
-    // against traversal inside the memory directory.
-    return cheap;
+    return undefined;
   }
 }
 

--- a/tests/unit/memory/memory-paths.test.ts
+++ b/tests/unit/memory/memory-paths.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   resolveMemoryDir,
   validateMemoryPath,
+  validateMemoryPathResolved,
   sanitizeFilename,
   ensureMemoryDir,
   isMemoryPath,
   validateThreadId,
 } from '../../../src/memory/memory-paths.js';
-import { sep } from 'node:path';
+import { sep, join } from 'node:path';
+import { mkdir, symlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 
 describe('memory-paths', () => {
   const originalEnv = process.env;
@@ -133,6 +136,34 @@ describe('memory-paths', () => {
   describe('ensureMemoryDir', () => {
     it('should be a function', () => {
       expect(typeof ensureMemoryDir).toBe('function');
+    });
+  });
+
+  describe('validateMemoryPathResolved (#215)', () => {
+    it('rejects a dangling symlink inside the memory dir', async () => {
+      const memoryDir = join(tmpdir(), `agentx-test-215-${Date.now()}`);
+      await mkdir(memoryDir, { recursive: true });
+      const symlinkPath = join(memoryDir, 'evil.md');
+      // Create a symlink whose target does not exist (dangling symlink)
+      await symlink('/tmp/nonexistent-target-agentx-issue-215', symlinkPath);
+      try {
+        const result = await validateMemoryPathResolved(symlinkPath, memoryDir);
+        expect(result).toBeUndefined();
+      } finally {
+        await rm(memoryDir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns cheap path for a genuinely nonexistent file (safe for creates)', async () => {
+      const memoryDir = join(tmpdir(), `agentx-test-215-${Date.now()}`);
+      await mkdir(memoryDir, { recursive: true });
+      const nonexistent = join(memoryDir, 'new-file.md');
+      try {
+        const result = await validateMemoryPathResolved(nonexistent, memoryDir);
+        expect(result).toBe(nonexistent);
+      } finally {
+        await rm(memoryDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes TOCTOU vulnerability in `validateMemoryPathResolved` where a dangling symlink inside the memory directory was incorrectly allowed to pass validation
- Uses `lstat()` (which does not follow symlinks) before `realpath()` to distinguish a genuinely absent file from an existing-but-dangling symlink
- A dangling symlink (`memoryDir/evil.md → /etc/crontab` where target doesn't exist) previously caused `realpath()` to throw ENOENT and the catch-all returned the cheap path — enabling a write to follow the symlink outside the memory directory

## Root cause

`validateMemoryPathResolved` had a single catch block for all errors from `realpath()`. Since `realpath()` throws `ENOENT` for both "file doesn't exist" (safe for creates) and "dangling symlink target doesn't exist" (unsafe), both cases fell through to `return cheap`.

## Fix

Split into two try/catch blocks:
1. `lstat(cheap)` — throws `ENOENT` only when no filesystem entry exists at that path (file genuinely absent → return `cheap` for safe creates)
2. `realpath(cheap)` — only reached when `lstat` succeeded (entry exists); any throw here (dangling symlink, ELOOP, etc.) → `return undefined`

## Test plan

- [x] New RED test: creates a dangling symlink inside a temp memory dir and asserts `validateMemoryPathResolved` returns `undefined`
- [x] New GREEN test: genuinely nonexistent file still returns `cheap` (safe for creates)
- [x] Full test suite passes (931 tests, 0 regressions)

Closes #215

https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_