### PR TITLE
fix(tool-executor,skill-manager): pass real recentMessages to validate/match contexts (#214)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -766,7 +766,8 @@ export class Agent {
     // Skills injection
     const skillToolNames: string[] = [];
     if (this.skillManager) {
-      const matchedSkills = await this.skillManager.match(userInput, { threadId });
+      const recentMessages = this.conversations.getHistory(threadId).length;
+      const matchedSkills = await this.skillManager.match(userInput, { threadId, recentMessages });
 
       for (const skill of matchedSkills) {
         // Resolve instructions (dynamic getPrompt or static with arg substitution)

--- a/src/core/react-loop.ts
+++ b/src/core/react-loop.ts
@@ -198,7 +198,12 @@ export async function* executeReactLoop(
     const earlyToolResults: LLMMessage[] = []; // Tool results completed during streaming
 
     // --- Stream from LLM ---
-    const streamingExecutor = new StreamingToolExecutor(toolExecutor, signal);
+    const streamingExecutor = new StreamingToolExecutor(
+      toolExecutor,
+      signal,
+      undefined,
+      messages.length,
+    );
     const effectiveMaxTokens = state.maxOutputTokensOverride ?? maxOutputTokens;
 
     try {

--- a/src/core/streaming-tool-executor.ts
+++ b/src/core/streaming-tool-executor.ts
@@ -41,13 +41,15 @@ export class StreamingToolExecutor {
   private readonly executor: ToolExecutor;
   private readonly signal?: AbortSignal;
   private readonly logger: Logger;
+  private readonly recentMessages: number;
   private processing = false;
   /** Accumulated progress events from all tools (drained by getProgressEvents) */
   private pendingProgress: ToolProgressInfo[] = [];
 
-  constructor(executor: ToolExecutor, signal?: AbortSignal, logger?: Logger) {
+  constructor(executor: ToolExecutor, signal?: AbortSignal, logger?: Logger, recentMessages = 0) {
     this.executor = executor;
     this.signal = signal;
+    this.recentMessages = recentMessages;
     this.logger = logger ?? createLogger({ prefix: 'streaming-tool-executor' });
   }
 
@@ -212,6 +214,7 @@ export class StreamingToolExecutor {
       const result = await this.executor.execute(tracked.name, parsedArgs, {
         signal: this.signal,
         toolCallId: tracked.id,
+        recentMessages: this.recentMessages,
         onProgress,
       });
       tracked.result = result;

--- a/src/skills/skill-manager.ts
+++ b/src/skills/skill-manager.ts
@@ -127,7 +127,10 @@ export class SkillManager {
   /**
    * Matches skills against input. Returns top skills sorted by priority.
    */
-  async match(input: string, context: { threadId: string }): Promise<AgentSkill[]> {
+  async match(
+    input: string,
+    context: { threadId: string; recentMessages?: number },
+  ): Promise<AgentSkill[]> {
     const matches: SkillMatchResult[] = [];
     const matchedNames = new Set<string>();
     const eligible = this.getEligibleSkills();
@@ -176,7 +179,12 @@ export class SkillManager {
       }
 
       // 3. Custom match function
-      if (skill.match?.(input, { threadId: context.threadId, recentMessages: 0 })) {
+      if (
+        skill.match?.(input, {
+          threadId: context.threadId,
+          recentMessages: context.recentMessages ?? 0,
+        })
+      ) {
         matches.push({ skill, matchType: 'custom', score: 0.8 });
         matchedNames.add(skill.name);
       }

--- a/src/tools/tool-executor.ts
+++ b/src/tools/tool-executor.ts
@@ -20,6 +20,7 @@ export interface ExecuteOptions {
   signal?: AbortSignal;
   toolCallId?: string;
   threadId?: string;
+  recentMessages?: number;
   onProgress?: ToolProgressCallback;
 }
 
@@ -108,7 +109,7 @@ export class ToolExecutor {
       try {
         const validationError = await tool.validate(validatedArgs, {
           threadId: opts.threadId ?? 'default',
-          recentMessages: 0,
+          recentMessages: opts.recentMessages ?? 0,
         });
         if (validationError) {
           return { content: `Validation error: ${validationError}`, isError: true };

--- a/tests/unit/skills/skill-manager.test.ts
+++ b/tests/unit/skills/skill-manager.test.ts
@@ -600,4 +600,24 @@ Review TS code.`,
       expect(count).toBe(0);
     });
   });
+
+  describe('match() — recentMessages propagation (#214)', () => {
+    it('passes recentMessages from context to skill.match()', async () => {
+      let capturedRecentMessages: number | undefined;
+
+      manager.register(
+        createSkill({
+          name: 'ctx-skill',
+          match: (_input, ctx) => {
+            capturedRecentMessages = ctx.recentMessages;
+            return true;
+          },
+        }),
+      );
+
+      await manager.match('anything', { threadId: 't1', recentMessages: 5 });
+
+      expect(capturedRecentMessages).toBe(5);
+    });
+  });
 });

--- a/tests/unit/tools/tool-executor.test.ts
+++ b/tests/unit/tools/tool-executor.test.ts
@@ -393,4 +393,22 @@ describe('ToolExecutor', () => {
 
     expect(result.isError).toBeFalsy();
   });
+
+  it('should pass recentMessages from ExecuteOptions to validate() (#214)', async () => {
+    const executor = new ToolExecutor();
+    let capturedRecentMessages: number | undefined;
+
+    executor.register(
+      createTool({
+        validate: async (_args, context) => {
+          capturedRecentMessages = context.recentMessages;
+          return null;
+        },
+      }),
+    );
+
+    await executor.execute('test_tool', { input: 'hi' }, { recentMessages: 7 });
+
+    expect(capturedRecentMessages).toBe(7);
+  });
 });


### PR DESCRIPTION
## Summary

- `ToolExecutor.execute()` now forwards `recentMessages` from `ExecuteOptions` to `tool.validate()` instead of hardcoding `0`
- `SkillManager.match()` context now accepts `recentMessages?` and passes it to `skill.match()` instead of hardcoding `0`
- `StreamingToolExecutor` accepts `recentMessages` at construction and threads it into every `execute()` call — `ReactLoop` passes `messages.length` at the point of executor creation
- `Agent.buildInjectionsWithSkills()` fetches the live thread history length and passes it to `skillManager.match()`

## Root cause

Both hardcoded `recentMessages: 0` in two places:
- `src/tools/tool-executor.ts:111` — `tool.validate()` call
- `src/skills/skill-manager.ts:179` — `skill.match()` call

Tools and skills with logic that branches on `recentMessages` (e.g. "only validate if conversation is long enough") could never trigger because they always saw `0`.

## Test plan

- [x] New RED test in `tool-executor.test.ts`: passes `recentMessages: 7` in `ExecuteOptions`, asserts `validate()` receives `7`
- [x] New RED test in `skill-manager.test.ts`: calls `match()` with `recentMessages: 5`, asserts `skill.match()` receives `5`
- [x] Both tests are GREEN after the fix
- [x] Full suite passes (931 tests, 0 regressions)

Closes #214

https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_