### PR TITLE
fix(ssrf-guard): block missing IANA reserved ranges (#213)

### DIFF
--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -30,13 +30,17 @@ export function validateSsrfUrl(rawUrl: string): string | null {
   // IPv4 literal checks (loopback, private ranges, link-local metadata)
   const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
   if (ipv4) {
-    const [a, b] = ipv4.slice(1).map(Number) as [number, number, number, number];
+    const [a, b, c] = ipv4.slice(1).map(Number) as [number, number, number, number];
     if (a === 127) return 'Blocked loopback address';
     if (a === 10) return 'Blocked private range 10.0.0.0/8';
     if (a === 192 && b === 168) return 'Blocked private range 192.168.0.0/16';
     if (a === 172 && b >= 16 && b <= 31) return 'Blocked private range 172.16.0.0/12';
     if (a === 169 && b === 254) return 'Blocked link-local range (cloud metadata)';
     if (a === 100 && b >= 64 && b <= 127) return 'Blocked shared address space 100.64.0.0/10';
+    if (a === 198 && b >= 18 && b <= 19) return 'Blocked benchmarking range 198.18.0.0/15';
+    if (a === 192 && b === 0 && c === 2) return 'Blocked documentation range 192.0.2.0/24';
+    if (a === 198 && b === 51 && c === 100) return 'Blocked documentation range 198.51.100.0/24';
+    if (a === 203 && b === 0 && c === 113) return 'Blocked documentation range 203.0.113.0/24';
     if (a === 0) return 'Blocked 0.0.0.0/8';
   }
 

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -66,6 +66,34 @@ describe('validateSsrfUrl', () => {
     });
   });
 
+  // issue #213 — missing IANA reserved ranges
+  describe('missing IANA reserved ranges (#213)', () => {
+    it('blocks 198.18.0.0/15 (benchmarking, RFC 2544)', () => {
+      expect(validateSsrfUrl('http://198.18.0.1/')).not.toBeNull();
+      expect(validateSsrfUrl('http://198.19.255.255/')).not.toBeNull();
+    });
+
+    it('allows addresses just outside 198.18.0.0/15', () => {
+      expect(validateSsrfUrl('http://198.17.255.255/')).toBeNull();
+      expect(validateSsrfUrl('http://198.20.0.0/')).toBeNull();
+    });
+
+    it('blocks 192.0.2.0/24 (TEST-NET-1, RFC 5737)', () => {
+      expect(validateSsrfUrl('http://192.0.2.1/')).not.toBeNull();
+      expect(validateSsrfUrl('http://192.0.2.255/')).not.toBeNull();
+    });
+
+    it('blocks 198.51.100.0/24 (TEST-NET-2, RFC 5737)', () => {
+      expect(validateSsrfUrl('http://198.51.100.1/')).not.toBeNull();
+      expect(validateSsrfUrl('http://198.51.100.255/')).not.toBeNull();
+    });
+
+    it('blocks 203.0.113.0/24 (TEST-NET-3, RFC 5737)', () => {
+      expect(validateSsrfUrl('http://203.0.113.1/')).not.toBeNull();
+      expect(validateSsrfUrl('http://203.0.113.255/')).not.toBeNull();
+    });
+  });
+
   // issue #190 — NAT64 prefix 64:ff9b::/96 (RFC 6146) not blocked
   describe('NAT64 64:ff9b::/96 (issue #190)', () => {
     it('blocks NAT64 with embedded private 10.0.0.1 (dot-decimal form)', () => {


### PR DESCRIPTION
## Summary

- Adds four missing IANA-reserved IPv4 ranges to `validateSsrfUrl` that were previously allowed through the guard
- Extracts the third octet (`c`) from the IPv4 regex match to enable /24 range checks without an extra parse pass

## Missing ranges added

| Range | Purpose | RFC |
|---|---|---|
| `198.18.0.0/15` | Benchmarking | RFC 2544 |
| `192.0.2.0/24` | TEST-NET-1 (documentation) | RFC 5737 |
| `198.51.100.0/24` | TEST-NET-2 (documentation) | RFC 5737 |
| `203.0.113.0/24` | TEST-NET-3 (documentation) | RFC 5737 |

Documentation ranges are frequently used as "example IPs" in configs and tutorials — an attacker could set a webhook URL to `http://192.0.2.1/` on a misconfigured host that has those ranges routable.

## Test plan

- [x] 4 new RED tests confirm each range was previously allowed (returns `null`)
- [x] Boundary test: `198.17.255.255` and `198.20.0.0` are still allowed (outside `/15` range)
- [x] All tests GREEN after fix
- [x] Full suite passes (934 tests, 0 regressions)

Closes #213

https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_