### PR TITLE
fix(llm-client): add Zod runtime validation for chat and embed API responses (#217)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -5,13 +5,19 @@ import { retry } from '../utils/retry.js';
 import { buildReasoningArgs, isReasoningModel, requiresNoSystemRole } from './reasoning.js';
 import { validateSsrfUrl } from '../utils/ssrf-guard.js';
 
+const ToolCallSchema = z.object({
+  id: z.string(),
+  type: z.literal('function'),
+  function: z.object({ name: z.string(), arguments: z.string() }),
+});
+
 const ChatJsonSchema = z.object({
   choices: z
     .array(
       z.object({
         message: z.object({
           content: z.string().nullish(),
-          tool_calls: z.array(z.unknown()).optional(),
+          tool_calls: z.array(ToolCallSchema).optional(),
         }),
         finish_reason: z.string().nullish(),
       }),
@@ -168,7 +174,7 @@ export class LLMClient {
     return {
       content: choice.message.content ?? '',
       toolCalls: choice.message.tool_calls,
-      finishReason: choice.finish_reason,
+      finishReason: choice.finish_reason ?? 'stop',
       usage,
     };
   }

--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -1,14 +1,34 @@
-import type {
-  StreamChatParams,
-  ChatParams,
-  StreamChunk,
-  ChatResponse,
-  LLMToolCall,
-} from './message-types.js';
+import { z } from 'zod';
+import type { StreamChatParams, ChatParams, StreamChunk, ChatResponse } from './message-types.js';
 import type { TokenUsage } from '../contracts/entities/token-usage.js';
 import { retry } from '../utils/retry.js';
 import { buildReasoningArgs, isReasoningModel, requiresNoSystemRole } from './reasoning.js';
 import { validateSsrfUrl } from '../utils/ssrf-guard.js';
+
+const ChatJsonSchema = z.object({
+  choices: z
+    .array(
+      z.object({
+        message: z.object({
+          content: z.string().nullish(),
+          tool_calls: z.array(z.unknown()).optional(),
+        }),
+        finish_reason: z.string().nullish(),
+      }),
+    )
+    .optional(),
+  usage: z
+    .object({
+      prompt_tokens: z.number(),
+      completion_tokens: z.number(),
+      total_tokens: z.number(),
+    })
+    .optional(),
+});
+
+const EmbedJsonSchema = z.object({
+  data: z.array(z.object({ embedding: z.array(z.number()) })),
+});
 
 export interface LLMClientConfig {
   apiKey: string;
@@ -113,16 +133,9 @@ export class LLMClient {
   async chat(params: ChatParams): Promise<ChatResponse> {
     const response = await this.sendChatRequest(params, false);
 
-    interface ChatJson {
-      choices: {
-        message: { content?: string; tool_calls?: LLMToolCall[] };
-        finish_reason: string;
-      }[];
-      usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
-    }
-    let json: ChatJson;
+    let rawJson: unknown;
     try {
-      json = (await response.json()) as ChatJson;
+      rawJson = await response.json();
     } catch (e) {
       // Ensure body is fully consumed so the HTTP connection is returned to the pool
       await response.body?.cancel().catch(() => {
@@ -132,6 +145,13 @@ export class LLMClient {
         `Failed to parse LLM response: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
+    const chatParsed = ChatJsonSchema.safeParse(rawJson);
+    if (!chatParsed.success) {
+      throw new Error(
+        `LLM API returned invalid response (model=${this.model}): ${chatParsed.error.message.slice(0, 300)}`,
+      );
+    }
+    const json = chatParsed.data;
 
     const choice = json.choices?.[0];
     if (!choice) {
@@ -163,12 +183,9 @@ export class LLMClient {
       { maxRetries: 3, initialDelay: 1000, isRetryable: (e) => e instanceof RetryableError },
     );
 
-    interface EmbedJson {
-      data: { embedding: number[] }[];
-    }
-    let json: EmbedJson;
+    let rawJson: unknown;
     try {
-      json = (await response.json()) as EmbedJson;
+      rawJson = await response.json();
     } catch (e) {
       await response.body?.cancel().catch(() => {
         /* swallow — already in error path */
@@ -177,15 +194,14 @@ export class LLMClient {
         `Failed to parse LLM response: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
-
-    if (!json.data || !Array.isArray(json.data)) {
+    const embedParsed = EmbedJsonSchema.safeParse(rawJson);
+    if (!embedParsed.success) {
       throw new Error(
-        `LLM embed API returned unexpected response (model=${model ?? this.model}). ` +
-          `Response: ${JSON.stringify(json).slice(0, 200)}`,
+        `LLM API returned invalid response (model=${model ?? this.model}): ${embedParsed.error.message.slice(0, 300)}`,
       );
     }
 
-    return json.data.map((d) => d.embedding);
+    return embedParsed.data.data.map((d) => d.embedding);
   }
 
   private async fetchAPI(

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -350,13 +350,13 @@ describe('LLMClient', () => {
         }),
       );
 
-      await expect(client.embed(['hello'])).rejects.toThrow(/unexpected response/i);
+      await expect(client.embed(['hello'])).rejects.toThrow(/invalid response/i);
     });
 
     it('embed() throws informative error when json.data is not an array (#172)', async () => {
       mockFetch(new Response(JSON.stringify({ data: null }), { status: 200 }));
 
-      await expect(client.embed(['hello'])).rejects.toThrow(/unexpected response/i);
+      await expect(client.embed(['hello'])).rejects.toThrow(/invalid response/i);
     });
   });
 

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -514,6 +514,24 @@ describe('LLMClient', () => {
     });
   });
 
+  describe('Zod response validation (#217)', () => {
+    it('chat() throws a descriptive error when choices[0] lacks a message field', async () => {
+      mockFetch(
+        new Response(JSON.stringify({ choices: [{ finish_reason: 'stop' }] }), { status: 200 }),
+      );
+
+      await expect(client.chat({ messages: [{ role: 'user', content: 'Hi' }] })).rejects.toThrow(
+        /invalid response/i,
+      );
+    });
+
+    it('embed() throws a descriptive error when data entries have no embedding field', async () => {
+      mockFetch(new Response(JSON.stringify({ data: [{}] }), { status: 200 }));
+
+      await expect(client.embed(['hello'])).rejects.toThrow(/invalid response/i);
+    });
+  });
+
   describe('SSRF protection (issue #113)', () => {
     it('throws when baseUrl points to cloud metadata endpoint (169.254.169.254)', () => {
       expect(


### PR DESCRIPTION
## Summary

- Replaces `(await response.json()) as ChatJson` and `as EmbedJson` unsafe type assertions with proper Zod runtime validation
- A malformed chat response (e.g. `choices[0]` missing `message`) now throws `"LLM API returned invalid response"` instead of a raw `TypeError: Cannot read properties of undefined (reading 'content')`
- A malformed embed response (e.g. `data[0]` missing `embedding`) now throws instead of silently returning `[undefined]`
- Unused `LLMToolCall` import removed (was only referenced in the now-deleted inline `ChatJson` interface)

## Root cause

Both `chat()` and `embed()` used TypeScript `as T` casts after `response.json()`, which give zero runtime protection. Any provider that returns an unexpected shape (wrong types, missing fields) would either throw an unhandled `TypeError` deep in the code or return corrupted data silently.

## Design decisions

- `choices` is intentionally marked optional in `ChatJsonSchema` so that responses with no `choices` field still fall through to the existing `"LLM API returned empty choices"` error (preserving the #154 behavior)
- `EmbedJsonSchema.data` is required and each entry must have `embedding: number[]` — this catches the #172 cases at the schema boundary

## Test plan

- [x] New RED test: `chat()` with `choices: [{ finish_reason: "stop" }]` (missing `message`) → must throw `/invalid response/i`
- [x] New RED test: `embed()` with `data: [{}]` (missing `embedding`) → must throw `/invalid response/i`
- [x] Both RED tests GREEN after fix
- [x] Existing tests updated to match new error message wording: `embed()` cases (#172) now check `/invalid response/i` instead of `/unexpected response/i`
- [x] Full suite passes (931 tests, 0 regressions)

Closes #217

https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1

---
_Generated by [Claude Code](https://claude.ai/code/session_014qNCfjvomUTsPTX127nHM1)_