### PR TITLE
fix(vitest): add resolve alias agentx-sdk → src/index.ts (closes #188)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'url';
+import { resolve, dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'agentx-sdk': resolve(__dirname, './src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Issue
Closes #188

## Problema
`tests/unit/examples/teams-bot/agent-factory.test.ts` importa de `agentx-sdk` (o pacote em si). Sem um alias de resolução no vitest, o Vite/vitest não consegue encontrar o entry point do pacote quando `dist/` não existe, lançando:

```
Error: Failed to resolve entry for package "agentx-sdk". The package may have
incorrect main/module/exports specified in its package.json.
```

Isso quebrava o job `quality` do CI a cada execução sem um `pnpm build` prévio, causando a falha reportada em #188.

## Abordagem TDD
- **Teste em:** `tests/unit/examples/teams-bot/agent-factory.test.ts`
- **Falha antes do fix (red):** `Test Files 1 failed` — `packageEntryFailure` ao tentar resolver `agentx-sdk`
- **Implementação mínima em:** `vitest.config.ts` — adição de `resolve.alias` mapeando `agentx-sdk` → `./src/index.ts`
- **Suíte completa:** `Test Files 82 passed (82)` — 963 testes verdes

## Mudanças de regras (justificativa)
Nenhuma. O alias é acréscimo à configuração do vitest; não altera regras de lint, CI, contratos públicos ou dependências.

## Checklist
- [x] Teste antes do fix (red confirmado)
- [x] Suíte verde (82/82 arquivos, 963 testes)
- [x] Lint limpo (`pnpm lint` sem warnings)
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUjzvJpYuXxd4KUZrQjWJf)_