### PR TITLE
fix: bloqueia brace expansion no Bash tool — adiciona { } ao blocklist (closes #235)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -58,7 +58,7 @@ export function createBashTool(options: BashToolOptions = {}): AgentTool {
 
       // Reject shell metacharacters unconditionally — prevents chaining/injection
       // regardless of whether allowedCommands is set (issue #140).
-      const DANGEROUS_METACHAR = /[;&|`$<>()\n\\]/;
+      const DANGEROUS_METACHAR = /[;&|`$<>()\n\\{}]/;
       if (DANGEROUS_METACHAR.test(command)) {
         return {
           content: 'Command contains forbidden shell metacharacters',

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -184,6 +184,39 @@ describe('builtin/bash', () => {
     });
   });
 
+  describe('brace expansion blocked (issue #235)', () => {
+    it('blocks { in command — brace expansion bypass', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'cat {/etc/passwd,/etc/hostname}' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden/i);
+    });
+
+    it('blocks } in command', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo }' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden/i);
+    });
+
+    it('blocks brace expansion even with allowedCommands set', async () => {
+      const tool = createBashTool({ allowedCommands: ['git'] });
+      const result = await tool.execute({ command: 'git {log,--exec-path}' }, signal);
+      const parsed = typeof result === 'string' ? { content: result, isError: false } : result;
+      expect(parsed.isError).toBe(true);
+      expect(parsed.content).toMatch(/metachar|forbidden/i);
+    });
+
+    it('still allows commands without braces', async () => {
+      const tool = createBashTool();
+      const result = await tool.execute({ command: 'echo hello' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).toContain('hello');
+    });
+  });
+
   describe('timeout parameter bounds (issue #9)', () => {
     it('should reject timeout=0 (would disable exec timeout)', async () => {
       const tool = createBashTool();


### PR DESCRIPTION
## Issue
Closes #235

## Problema
Os caracteres `{` e `}` estavam ausentes do `DANGEROUS_METACHAR` regex em `src/tools/builtin/bash.ts`. Isso permitia brace expansion do shell, possibilitando bypass do `allowedCommands` e leitura de arquivos arbitrários.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/bash.test.ts` (describe `brace expansion blocked (issue #235)`)
- Falha antes do fix (red): 3 testes falharam — `{` e `}` não eram bloqueados
- Implementação mínima em: `src/tools/builtin/bash.ts:61` — regex `[;&|` + `` $<>()\n\\{}] ``
- Suíte completa: verde (952 testes, 1 falha pré-existente em teams-bot não relacionada)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_