### PR TITLE
fix: bloqueia IPv6 unspecified [::] no SSRF guard (closes #236)

### DIFF
--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -17,13 +17,7 @@ export function validateSsrfUrl(rawUrl: string): string | null {
   const host = parsed.hostname.toLowerCase();
 
   // Loopback and wildcard hostnames
-  if (
-    host === 'localhost' ||
-    host === '0.0.0.0' ||
-    host === '::1' ||
-    host === '[::1]' ||
-    host === '::'
-  ) {
+  if (host === 'localhost' || host === '0.0.0.0' || host === '[::1]' || host === '[::]') {
     return `Blocked hostname: ${host}`;
   }
 

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -94,6 +94,25 @@ describe('validateSsrfUrl', () => {
     });
   });
 
+  // issue #236 — IPv6 unspecified address [::] not blocked (host === '::' is dead code)
+  describe('IPv6 unspecified address [::] blocked (issue #236)', () => {
+    it('blocks http://[::] — IPv6 all-zeros unspecified address', () => {
+      expect(validateSsrfUrl('http://[::]/')).not.toBeNull();
+    });
+
+    it('blocks https://[::] as well', () => {
+      expect(validateSsrfUrl('https://[::]/')).not.toBeNull();
+    });
+
+    it('still blocks [::1] loopback IPv6', () => {
+      expect(validateSsrfUrl('http://[::1]/')).not.toBeNull();
+    });
+
+    it('still allows a public IPv6 address', () => {
+      expect(validateSsrfUrl('https://[2606:4700:4700::1111]/')).toBeNull();
+    });
+  });
+
   // issue #190 — NAT64 prefix 64:ff9b::/96 (RFC 6146) not blocked
   describe('NAT64 64:ff9b::/96 (issue #190)', () => {
     it('blocks NAT64 with embedded private 10.0.0.1 (dot-decimal form)', () => {


### PR DESCRIPTION
## Issue
Closes #236

## Problema
`host === '::'` era dead code — WHATWG URL retorna `[::]` com colchetes. Isso deixava `http://[::]` sem bloqueio (SSRF). Removido dead code, adicionado `host === '[::]'`.

## Abordagem TDD
- Teste em: `tests/unit/utils/ssrf-guard.test.ts`
- Falha antes do fix (red): 2 testes falharam
- Implementação mínima em: `src/utils/ssrf-guard.ts:20`
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_