### PR TITLE
fix: valida process.env.SHELL contra allowlist no Bash tool (closes #238)

### DIFF
--- a/src/tools/builtin/bash.ts
+++ b/src/tools/builtin/bash.ts
@@ -25,6 +25,19 @@ function killTree(pid: number | undefined, signal: NodeJS.Signals = 'SIGTERM'): 
 const DEFAULT_TIMEOUT = 120_000;
 const MAX_OUTPUT = 500_000; // 500KB
 
+const ALLOWED_SHELLS = new Set([
+  '/bin/sh',
+  '/bin/bash',
+  '/usr/bin/bash',
+  '/bin/dash',
+  '/usr/bin/dash',
+]);
+
+function resolveShell(): string {
+  const envShell = process.env.SHELL?.trim();
+  return envShell && ALLOWED_SHELLS.has(envShell) ? envShell : '/bin/sh';
+}
+
 const BashParams = z.object({
   command: z.string().describe('Shell command to execute'),
   timeout: z
@@ -88,7 +101,7 @@ export function createBashTool(options: BashToolOptions = {}): AgentTool {
           {
             timeout: effectiveTimeout,
             maxBuffer: MAX_OUTPUT,
-            shell: process.env.SHELL?.trim() ? process.env.SHELL : '/bin/sh',
+            shell: resolveShell(),
             ...(workingDir ? { cwd: workingDir } : {}),
             // Detach on POSIX so the child gets its own process group —
             // lets us kill the whole tree (including backgrounded grandchildren).

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -225,6 +225,9 @@ describe('builtin/bash', () => {
         if (saved !== undefined) process.env.SHELL = saved;
         else delete process.env.SHELL;
       }
+    });
+  });
+
   describe('brace expansion blocked (issue #235)', () => {
     it('blocks { in command — brace expansion bypass', async () => {
       const tool = createBashTool();

--- a/tests/unit/tools/builtin/bash.test.ts
+++ b/tests/unit/tools/builtin/bash.test.ts
@@ -184,6 +184,50 @@ describe('builtin/bash', () => {
     });
   });
 
+  describe('SHELL env validation (issue #238)', () => {
+    it('uses /bin/sh when SHELL is not set', async () => {
+      const saved = process.env.SHELL;
+      delete process.env.SHELL;
+      try {
+        const tool = createBashTool();
+        const result = await tool.execute({ command: 'echo ok' }, signal);
+        const content = typeof result === 'string' ? result : result.content;
+        expect(content).toContain('ok');
+      } finally {
+        if (saved !== undefined) process.env.SHELL = saved;
+      }
+    });
+
+    it('accepts /bin/bash as an allowed shell', async () => {
+      const saved = process.env.SHELL;
+      process.env.SHELL = '/bin/bash';
+      try {
+        const tool = createBashTool();
+        const result = await tool.execute({ command: 'echo bash-ok' }, signal);
+        const content = typeof result === 'string' ? result : result.content;
+        expect(content).toContain('bash-ok');
+      } finally {
+        if (saved !== undefined) process.env.SHELL = saved;
+        else delete process.env.SHELL;
+      }
+    });
+
+    it('falls back to /bin/sh when SHELL is not in allowlist', async () => {
+      const saved = process.env.SHELL;
+      process.env.SHELL = '/tmp/malicious-shell';
+      try {
+        const tool = createBashTool();
+        // Command must still execute — just not with the untrusted shell
+        const result = await tool.execute({ command: 'echo fallback-ok' }, signal);
+        const content = typeof result === 'string' ? result : result.content;
+        expect(content).toContain('fallback-ok');
+      } finally {
+        if (saved !== undefined) process.env.SHELL = saved;
+        else delete process.env.SHELL;
+      }
+    });
+  });
+
   describe('timeout parameter bounds (issue #9)', () => {
     it('should reject timeout=0 (would disable exec timeout)', async () => {
       const tool = createBashTool();


### PR DESCRIPTION
## Issue
Closes #238

## Problema
`process.env.SHELL` era passado diretamente para `child_process.exec()` sem validação. Um valor como `/tmp/malicious-shell` seria usado como shell, podendo executar comandos em shell não-esperado ou um binário arbitrário.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/bash.test.ts` (describe `SHELL env validation (issue #238)`)
  - Verifica que SHELL ausente usa `/bin/sh`
  - Verifica que `/bin/bash` é aceito
  - Verifica que `/tmp/malicious-shell` é rejeitado e cai para `/bin/sh` (fallback)
- Falha antes do fix (red): 1 teste falhou — `spawn /tmp/malicious-shell ENOENT`
- Implementação mínima em: `src/tools/builtin/bash.ts`
  - Adicionada `ALLOWED_SHELLS` e `resolveShell()` que retorna `/bin/sh` para valores fora da allowlist
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_