### PR TITLE
fix: remove dead-code '::1' sem colchetes no SSRF guard (closes #239)

### DIFF
--- a/src/utils/ssrf-guard.ts
+++ b/src/utils/ssrf-guard.ts
@@ -17,13 +17,7 @@ export function validateSsrfUrl(rawUrl: string): string | null {
   const host = parsed.hostname.toLowerCase();
 
   // Loopback and wildcard hostnames
-  if (
-    host === 'localhost' ||
-    host === '0.0.0.0' ||
-    host === '::1' ||
-    host === '[::1]' ||
-    host === '::'
-  ) {
+  if (host === 'localhost' || host === '0.0.0.0' || host === '[::1]' || host === '::') {
     return `Blocked hostname: ${host}`;
   }
 

--- a/tests/unit/utils/ssrf-guard.test.ts
+++ b/tests/unit/utils/ssrf-guard.test.ts
@@ -38,6 +38,20 @@ describe('validateSsrfUrl', () => {
     expect(validateSsrfUrl('http://localhost/')).not.toBeNull();
   });
 
+  // issue #239 — dead code: '::1' (without brackets) never matches WHATWG URL hostname
+  describe('IPv6 loopback blocked via bracket form only (issue #239)', () => {
+    it('blocks http://[::1]/ — WHATWG URL hostname is [::1] with brackets', () => {
+      expect(validateSsrfUrl('http://[::1]/')).not.toBeNull();
+    });
+
+    it('http://::1/ is an invalid URL — covered by invalid-URL guard, not the ::1 check', () => {
+      // Without brackets, ::1 is not a valid HTTP URL; the URL parser rejects it.
+      // The dead-code check host === '::1' can never be true for a valid URL.
+      const result = validateSsrfUrl('http://::1/');
+      expect(result).toBe('Invalid URL');
+    });
+  });
+
   it('blocks non-http/https schemes', () => {
     expect(validateSsrfUrl('file:///etc/passwd')).not.toBeNull();
     expect(validateSsrfUrl('ftp://example.com/')).not.toBeNull();


### PR DESCRIPTION
## Issue
Closes #239

## Problema
`host === '::1'` (sem colchetes) em `src/utils/ssrf-guard.ts` era dead code — o parser WHATWG URL sempre retorna `[::1]` (com colchetes) como hostname para endereços IPv6. A verificação redundante criava confusão para mantenedores: alguém poderia remover `'[::1]'` acreditando que `'::1'` cobre o mesmo caso.

Não há gap de segurança (o `host === '[::1]'` já bloqueia corretamente), mas o dead code aumenta o risco de regressão futura.

## Abordagem TDD
- Testes em: `tests/unit/utils/ssrf-guard.test.ts` (describe `IPv6 loopback blocked via bracket form only (issue #239)`)
  - Documenta que `http://[::1]/` é bloqueado pelo check `[::1]`
  - Documenta que `http://::1/` retorna `'Invalid URL'` (inválido via URL parser — prova que `'::1'` nunca é atingível como hostname)
- Dead code removal não muda comportamento → testes passam antes e depois
- Suíte completa: verde

## Nota sobre `host === '::'`
A entrada `'::'` também é dead code, mas tem implicação de segurança (gap `[::]`) tratada em issue #236 (high). Esta PR toca apenas `'::1'` para minimizar escopo.

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste documenta comportamento correto
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_