### PR TITLE
fix: limite de 512 KB em loadSkillFile — previne DoS por arquivo grande (closes #240)

### DIFF
--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -116,8 +116,12 @@ export function extractBody(content: string): string {
 /**
  * Load a single SKILL.md file into an AgentSkill.
  */
+const MAX_SKILL_FILE_BYTES = 512 * 1024; // 512 KB
+
 export async function loadSkillFile(filePath: string): Promise<AgentSkill | null> {
   try {
+    const fileInfo = await stat(filePath);
+    if (fileInfo.size > MAX_SKILL_FILE_BYTES) return null;
     const content = await readFile(filePath, 'utf-8');
     const fm = parseSkillFrontmatter(content);
     const body = extractBody(content);

--- a/tests/unit/skills/skill-loader.test.ts
+++ b/tests/unit/skills/skill-loader.test.ts
@@ -216,6 +216,31 @@ Review $file carefully.`,
       const skill = await loadSkillFile(join(skillDir, 'SKILL.md'));
       expect(skill).toBeNull();
     });
+
+    // issue #240 — no size limit before readFile — large file DoS
+    it('should return null for SKILL.md exceeding 512 KB (DoS guard)', async () => {
+      const skillDir = join(tempDir, 'huge');
+      await mkdir(skillDir);
+      // Write a file slightly over 512 KB
+      const oversized = 'x'.repeat(513 * 1024);
+      await writeFile(join(skillDir, 'SKILL.md'), oversized);
+
+      const skill = await loadSkillFile(join(skillDir, 'SKILL.md'));
+      expect(skill).toBeNull();
+    });
+
+    it('should load a SKILL.md exactly at the 512 KB limit', async () => {
+      const skillDir = join(tempDir, 'maxsize');
+      await mkdir(skillDir);
+      // Frontmatter + instructions padded to just under 512 KB
+      const header = '---\nname: big-skill\ndescription: Big\n---\n\n';
+      const padding = 'a'.repeat(512 * 1024 - header.length);
+      await writeFile(join(skillDir, 'SKILL.md'), header + padding);
+
+      const skill = await loadSkillFile(join(skillDir, 'SKILL.md'));
+      expect(skill).not.toBeNull();
+      expect(skill!.name).toBe('big-skill');
+    });
   });
 
   describe('scanSkillFiles', () => {


### PR DESCRIPTION
## Issue
Closes #240

## Problema
`loadSkillFile` chamava `readFile(filePath, 'utf-8')` sem verificar o tamanho do arquivo antes. Um SKILL.md artificialmente grande (em `skillsDir` apontando para repositórios externos, volumes Docker montados ou ambientes multi-tenant) podia esgotar a heap do processo Node.js (CWE-400 / CWE-770).

## Abordagem TDD
- Teste em: `tests/unit/skills/skill-loader.test.ts` (describe `loadSkillFile`)
  - `should return null for SKILL.md exceeding 512 KB` — arquivo de 513 KB deve retornar null (falhou antes do fix → RED)
  - `should load a SKILL.md exactly at the 512 KB limit` — arquivo no limite deve ser carregado normalmente
- Falha antes do fix (red): 1 teste falhou — arquivo grande era carregado sem rejeição
- Implementação mínima em: `src/skills/skill-loader.ts`
  - Adicionado `stat()` antes de `readFile()`; arquivos > `MAX_SKILL_FILE_BYTES` (512 KB) retornam `null`
- Suíte completa: verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_