### PR TITLE
chore: ignore root package-lock.json — projeto usa pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+/package-lock.json
 *.db
 *.db-wal
 *.db-shm


### PR DESCRIPTION
## Problema
O arquivo `package-lock.json` na raiz do repositório era untracked. Ele foi gerado acidentalmente por `npm install` durante sessão de desenvolvimento. O projeto usa `pnpm` como gerenciador de pacotes (evidenciado por `pnpm-lock.yaml`).

## Solução
Adiciona `/package-lock.json` ao `.gitignore` (apenas na raiz — os lockfiles dos exemplos já estavam ignorados separadamente).

## Checklist
- [x] Sem impacto em testes ou comportamento de runtime
- [x] Consistente com as entradas existentes no `.gitignore` para os exemplos

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsrYZMpQsjMgqebVUmznDo)_