### PR TITLE
fix: cost_warning emitido apenas uma vez com onLimitReached warn (closes #253)

### DIFF
--- a/src/core/react-loop.ts
+++ b/src/core/react-loop.ts
@@ -101,6 +101,7 @@ export async function* executeReactLoop(
   // Token budget continuation tracking
   let budgetContinuationCount = 0;
   let cumulativeOutputTokens = 0;
+  let costWarningEmitted = false;
 
   let state: LoopState = createInitialState([...initialMessages]);
 
@@ -120,7 +121,10 @@ export async function* executeReactLoop(
       if (costPolicy.onLimitReached === 'stop') {
         return { reason: 'cost_limit', usage };
       }
-      yield { type: 'warning', message: 'Token limit approaching', code: 'cost_warning' };
+      if (!costWarningEmitted) {
+        yield { type: 'warning', message: 'Token limit approaching', code: 'cost_warning' };
+        costWarningEmitted = true;
+      }
     }
 
     // --- Check max iterations ---

--- a/tests/unit/core/react-loop.test.ts
+++ b/tests/unit/core/react-loop.test.ts
@@ -358,4 +358,69 @@ describe('executeReactLoop', () => {
     const { terminal } = await consumeLoop(gen);
     expect(terminal.reason).toBe('error');
   });
+
+  it('should emit cost_warning exactly once when onLimitReached is warn (issue #253)', async () => {
+    // Bug: cost_warning was emitted on EVERY iteration after limit is exceeded, not just once.
+    // Turn 1 returns 300 tokens (exceeds limit of 200) via tool_calls so the loop continues.
+    // Turn 2 and 3 also return tool_calls, keeping the loop alive past the limit.
+    // Turn 4 returns stop. With the bug, turns 2, 3, and 4 each emit a separate cost_warning.
+    const client = createMockClient([
+      [
+        { type: 'tool_call', id: 't1', name: 'noop', arguments: '{}' },
+        {
+          type: 'done',
+          finishReason: 'tool_calls',
+          usage: { inputTokens: 150, outputTokens: 150, totalTokens: 300 },
+        },
+      ],
+      [
+        { type: 'tool_call', id: 't2', name: 'noop', arguments: '{}' },
+        {
+          type: 'done',
+          finishReason: 'tool_calls',
+          usage: { inputTokens: 150, outputTokens: 150, totalTokens: 300 },
+        },
+      ],
+      [
+        { type: 'tool_call', id: 't3', name: 'noop', arguments: '{}' },
+        {
+          type: 'done',
+          finishReason: 'tool_calls',
+          usage: { inputTokens: 150, outputTokens: 150, totalTokens: 300 },
+        },
+      ],
+      [
+        { type: 'content', data: 'done' },
+        {
+          type: 'done',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+        },
+      ],
+    ]);
+
+    const executor = new ToolExecutor();
+    executor.register({
+      name: 'noop',
+      description: 'No-op',
+      parameters: z.object({}),
+      execute: vi.fn().mockResolvedValue('ok'),
+    });
+
+    const gen = executeReactLoop([{ role: 'user', content: 'test' }], {
+      client,
+      toolExecutor: executor,
+      model: 'test',
+      maxIterations: 10,
+      maxConsecutiveErrors: 3,
+      onToolError: 'continue',
+      costPolicy: { maxTokensPerExecution: 200, onLimitReached: 'warn' },
+    });
+
+    const { events } = await consumeLoop(gen);
+    const warnings = events.filter(
+      (e) => e.type === 'warning' && (e as { code?: string }).code === 'cost_warning',
+    );
+    expect(warnings).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Issue
Closes #253

## Problema
Com `costPolicy.onLimitReached: 'warn'`, o evento `cost_warning` era emitido em **todas** as iterações após o limite ser atingido, em vez de apenas uma vez. O loop continuava chamando o LLM indefinidamente (até `maxIterations`), acumulando custos muito além do limite configurado e enviando spam de eventos ao caller.

## Abordagem TDD
- Teste em: `tests/unit/core/react-loop.test.ts`
- Falha antes do fix (red): 3 eventos `cost_warning` emitidos (um por iteração pós-limite)
- Implementação mínima em: `src/core/react-loop.ts` — adicionado flag `costWarningEmitted` que garante emissão única
- Suíte completa: verde (981 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxSSZ7sn5CpzxJYcymMqtP)_