### PR TITLE
fix: glob respeita AbortSignal e pula node_modules (closes #254)

### DIFF
--- a/src/tools/builtin/glob.ts
+++ b/src/tools/builtin/glob.ts
@@ -12,13 +12,15 @@ const GlobParams = z.object({
   path: z.string().optional().describe('Directory to search in. Defaults to cwd.'),
 });
 
-async function walkDir(dir: string, results: string[]): Promise<void> {
+async function walkDir(dir: string, results: string[], signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
   const entries = await readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue;
+    if (signal.aborted) return;
+    if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      await walkDir(full, results);
+      await walkDir(full, results, signal);
     } else {
       results.push(full);
     }
@@ -34,7 +36,7 @@ export function createGlobTool(workingDir?: string): AgentTool {
     isConcurrencySafe: true,
     isReadOnly: true,
 
-    async execute(rawArgs: unknown, _signal: AbortSignal) {
+    async execute(rawArgs: unknown, signal: AbortSignal) {
       const { pattern, path: searchPath } = rawArgs as z.infer<typeof GlobParams>;
 
       let baseDir: string;
@@ -46,7 +48,7 @@ export function createGlobTool(workingDir?: string): AgentTool {
 
       const allFiles: string[] = [];
       try {
-        await walkDir(baseDir, allFiles);
+        await walkDir(baseDir, allFiles, signal);
       } catch {
         return { content: `Cannot read directory: ${baseDir}`, isError: true };
       }

--- a/tests/unit/tools/builtin/glob.test.ts
+++ b/tests/unit/tools/builtin/glob.test.ts
@@ -51,6 +51,31 @@ describe('builtin/glob', () => {
     expect(content).toContain('No files found');
   });
 
+  describe('issue #254 — AbortSignal and node_modules', () => {
+    it('should not traverse node_modules directories', async () => {
+      // Bug: walkDir only skipped entries starting with '.'; node_modules was traversed in full.
+      await mkdir(join(tempDir, 'node_modules', 'some-pkg'), { recursive: true });
+      await writeFile(join(tempDir, 'node_modules', 'some-pkg', 'lib.ts'), 'export {}');
+
+      const tool = createGlobTool(tempDir);
+      const result = await tool.execute({ pattern: '**/*.ts' }, signal);
+      const content = typeof result === 'string' ? result : result.content;
+      expect(content).not.toContain('node_modules');
+    });
+
+    it('should stop walkDir early when AbortSignal is already aborted', async () => {
+      // Bug: _signal parameter was ignored; walkDir completed full traversal even after abort.
+      const ac = new AbortController();
+      ac.abort();
+
+      const tool = createGlobTool(tempDir);
+      const result = await tool.execute({ pattern: '**/*.ts', path: tempDir }, ac.signal);
+      const content = typeof result === 'string' ? result : result.content;
+      // When aborted before traversal starts, no files should be collected.
+      expect(content).toContain('No files found');
+    });
+  });
+
   describe('path containment (issue #70)', () => {
     it('should block path outside workingDir when workingDir is set', async () => {
       const tool = createGlobTool(tempDir);


### PR DESCRIPTION
## Issue
Closes #254

## Problema
O `createGlobTool` tinha dois problemas distintos:
1. **AbortSignal ignorado**: `_signal` era recebido mas nunca passado ao `walkDir`, impossibilitando cancelamento após abort.
2. **`node_modules` não ignorado**: a função `walkDir` só pulava entradas começando com `.`; um projeto Node.js típico tem milhares de arquivos em `node_modules` que seriam percorridos antes do filtro.

## Abordagem TDD
- Teste em: `tests/unit/tools/builtin/glob.test.ts`
- Falha antes do fix (red): 2 testes falhando — node_modules aparecia nos resultados; sinal abortado era ignorado
- Implementação mínima em: `src/tools/builtin/glob.ts` — `walkDir` agora aceita `signal: AbortSignal`, verifica `signal.aborted` no início e a cada entrada, e pula entradas `node_modules`
- Suíte completa: verde (982 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxSSZ7sn5CpzxJYcymMqtP)_