### PR TITLE
fix: stop_hook_blocking recovery incrementa attempt corretamente (closes #255)

### DIFF
--- a/src/core/loop-types.ts
+++ b/src/core/loop-types.ts
@@ -55,6 +55,8 @@ export interface LoopState {
   readonly transition: Continue | undefined;
   /** Tracks tool-level retry attempts (onToolError: 'retry'). */
   readonly toolRetryCount: number;
+  /** Tracks consecutive stop_hook_blocking recovery attempts. */
+  readonly stopHookRetryCount: number;
 }
 
 /** Create initial loop state from the starting messages */
@@ -69,5 +71,6 @@ export function createInitialState(messages: LLMMessage[]): LoopState {
     autoCompactTracking: undefined,
     transition: undefined,
     toolRetryCount: 0,
+    stopHookRetryCount: 0,
   };
 }

--- a/src/core/react-loop.ts
+++ b/src/core/react-loop.ts
@@ -342,7 +342,8 @@ export async function* executeReactLoop(
           }
 
           if (hookResult.blockingErrors.length > 0) {
-            yield { type: 'recovery', reason: 'stop_hook_blocking', attempt: 1 };
+            const stopHookRetryCount = state.stopHookRetryCount + 1;
+            yield { type: 'recovery', reason: 'stop_hook_blocking', attempt: stopHookRetryCount };
 
             const errorMessages: LLMMessage[] = hookResult.blockingErrors.map((err) => ({
               role: 'user' as const,
@@ -353,6 +354,7 @@ export async function* executeReactLoop(
               ...state,
               messages: [...messages, assistantMessage, ...errorMessages],
               turnCount: turnCount + 1,
+              stopHookRetryCount,
               transition: { reason: 'stop_hook_blocking' },
             };
             continue;

--- a/tests/unit/core/stop-hooks.test.ts
+++ b/tests/unit/core/stop-hooks.test.ts
@@ -199,4 +199,73 @@ describe('Stop Hooks', () => {
     // Hook only called once (on the final text response, not on tool call iteration)
     expect(hookExecute).toHaveBeenCalledOnce();
   });
+
+  it('should increment attempt counter on each stop_hook_blocking recovery (issue #255)', async () => {
+    // Bug: attempt was hardcoded to 1 on every iteration; it should increment like other counters.
+    const hook: StopHook = {
+      name: 'always-blocking',
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce({ blockingErrors: ['err1'], preventContinuation: false })
+        .mockResolvedValueOnce({ blockingErrors: ['err2'], preventContinuation: false })
+        .mockResolvedValueOnce({ blockingErrors: ['err3'], preventContinuation: false })
+        .mockResolvedValue({ blockingErrors: [], preventContinuation: false }),
+    };
+
+    const client = createMockClient([
+      [
+        { type: 'content', data: 'attempt 1' },
+        {
+          type: 'done',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+        },
+      ],
+      [
+        { type: 'content', data: 'attempt 2' },
+        {
+          type: 'done',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+        },
+      ],
+      [
+        { type: 'content', data: 'attempt 3' },
+        {
+          type: 'done',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+        },
+      ],
+      [
+        { type: 'content', data: 'done' },
+        {
+          type: 'done',
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+        },
+      ],
+    ]);
+
+    const executor = new ToolExecutor();
+    const gen = executeReactLoop([{ role: 'user', content: 'test' }], {
+      client,
+      toolExecutor: executor,
+      model: 'test',
+      maxIterations: 10,
+      maxConsecutiveErrors: 3,
+      onToolError: 'continue',
+      stopHooks: [hook],
+    });
+
+    const { events } = await consumeLoop(gen);
+    const recoveryEvents = events.filter(
+      (e) => e.type === 'recovery' && (e as { reason?: string }).reason === 'stop_hook_blocking',
+    );
+
+    expect(recoveryEvents).toHaveLength(3);
+    expect((recoveryEvents[0] as { attempt: number }).attempt).toBe(1);
+    expect((recoveryEvents[1] as { attempt: number }).attempt).toBe(2);
+    expect((recoveryEvents[2] as { attempt: number }).attempt).toBe(3);
+  });
 });


### PR DESCRIPTION
## Issue
Closes #255

## Problema
O evento `recovery` com `reason: 'stop_hook_blocking'` sempre emitia `attempt: 1` em todas as iterações, ao contrário de outros motivos de recovery (como `max_output_tokens_recovery` e `token_budget_continuation`) que incrementam corretamente. Callers que rastreiam tentativas pela propriedade `attempt` não conseguiam distinguir a primeira da segunda, terceira, etc. tentativas.

## Abordagem TDD
- Teste em: `tests/unit/core/stop-hooks.test.ts`
- Falha antes do fix (red): `attempt` retornava `1` na segunda e terceira iterações ao invés de `2` e `3`
- Implementação mínima em: `src/core/loop-types.ts` (campo `stopHookRetryCount` adicionado ao `LoopState`) e `src/core/react-loop.ts` (usa contador incremental, padrão idêntico ao `maxOutputTokensRecoveryCount`)
- Suíte completa: verde (981 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxSSZ7sn5CpzxJYcymMqtP)_