### PR TITLE
fix: limite de 1 MB no buffer SSE em parseSSEStream (closes #261)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -239,6 +239,8 @@ export class LLMClient {
     const decoder = new TextDecoder();
     let buffer = '';
 
+    const MAX_SSE_BUFFER = 1 * 1024 * 1024; // 1 MB
+
     // Accumulate tool calls incrementally
     const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
 
@@ -272,7 +274,16 @@ export class LLMClient {
           break;
         }
 
-        buffer += decoder.decode(value, { stream: true });
+        const chunk = decoder.decode(value, { stream: true });
+        if (buffer.length + chunk.length > MAX_SSE_BUFFER) {
+          reader.cancel().catch(() => {
+            /* swallow */
+          });
+          throw new Error(
+            `SSE buffer limit exceeded (${MAX_SSE_BUFFER} bytes) — possible malformed stream`,
+          );
+        }
+        buffer += chunk;
         const lines = buffer.split('\n');
         buffer = lines.pop() ?? '';
 

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -514,6 +514,51 @@ describe('LLMClient', () => {
     });
   });
 
+  describe('SSE buffer limit (issue #261)', () => {
+    it('throws when a single SSE line exceeds 1 MB without a newline', async () => {
+      // Simulate a malformed/malicious SSE stream that sends a chunk > 1 MB with no newline,
+      // causing the buffer to grow unbounded. The fix must detect this and abort the stream.
+      const encoder = new TextEncoder();
+      // Build a chunk of 1.1 MB with no newline — this is one huge line with no SSE delimiter.
+      const hugeLine = 'data: ' + 'x'.repeat(1_100_000);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(hugeLine));
+          controller.close();
+        },
+      });
+      const response = new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+      mockFetch(response);
+
+      await expect(async () => {
+        for await (const _ of client.streamChat({
+          messages: [{ role: 'user', content: 'Hi' }],
+        })) {
+          /* consume */
+        }
+      }).rejects.toThrow(/SSE buffer limit exceeded/i);
+    });
+
+    it('does not throw for normal SSE traffic well under 1 MB', async () => {
+      const sseResponse = createSSEResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}',
+        'data: {"choices":[{"finish_reason":"stop","index":0}]}',
+      ]);
+      mockFetch(sseResponse);
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of client.streamChat({
+        messages: [{ role: 'user', content: 'Hi' }],
+      })) {
+        chunks.push(chunk);
+      }
+      expect(chunks.some((c) => c.type === 'content')).toBe(true);
+    });
+  });
+
   describe('SSRF protection (issue #113)', () => {
     it('throws when baseUrl points to cloud metadata endpoint (169.254.169.254)', () => {
       expect(


### PR DESCRIPTION
## Issue
Closes #261

## Problema
O acumulador `buffer` em `parseSSEStream` crescia sem limite. Um provedor SSE malformado ou comprometido (ou `baseUrl` apontando para endpoint adversarial) podia enviar um chunk sem quebra de linha de vários MB, causando OOM / crash do processo.

## Abordagem TDD
- Teste em: `tests/unit/llm/llm-client.test.ts` (describe "SSE buffer limit (issue #261)")
- Falha antes do fix (red): o stream resolvia normalmente sem rejeitar
- Implementação mínima em: `src/llm/llm-client.ts` — constante `MAX_SSE_BUFFER = 1 MB`, guard antes de acumular cada chunk
- Suíte completa: verde (986 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfW22bny5s2JPtVoJNhVL)_