### PR TITLE
fix: limite de 512 KB em readMemory antes de readFile (closes #262)

### DIFF
--- a/src/memory/file-memory-system.ts
+++ b/src/memory/file-memory-system.ts
@@ -132,13 +132,15 @@ export class FileMemorySystem {
    * When threadId is provided, reads from thread subdirectory.
    */
   async readMemory(filename: string, threadId?: string): Promise<MemoryFile | null> {
+    const MAX_MEMORY_FILE_BYTES = 512 * 1024; // 512 KB
     try {
       const dir = this.resolveDir(threadId);
       const candidate = join(dir, filename);
       const filePath = await validateMemoryPathResolved(candidate, this.memoryDir);
       if (!filePath) return null;
-      const content = await readFile(filePath, 'utf-8');
       const fileStat = await stat(filePath);
+      if (fileStat.size > MAX_MEMORY_FILE_BYTES) return null;
+      const content = await readFile(filePath, 'utf-8');
       const frontmatter = parseFrontmatter(content);
 
       const bodyMatch = /^---\s*\n[\s\S]*?\n---\s*\n?([\s\S]*)/.exec(content);

--- a/tests/unit/memory/file-memory-system.test.ts
+++ b/tests/unit/memory/file-memory-system.test.ts
@@ -126,6 +126,18 @@ describe('FileMemorySystem', () => {
       const result = await system.readMemory('nonexistent.md');
       expect(result).toBeNull();
     });
+
+    it('returns null and does not load content for memory file exceeding 512 KB (issue #262)', async () => {
+      // Write a memory file that is exactly over 512 KB
+      const oversized =
+        '---\nname: Big\ndescription: oversized\ntype: user\n---\n\n' + 'x'.repeat(512 * 1024 + 1);
+      await writeFile(join(tempDir, 'big.md'), oversized);
+
+      // Before fix: readFile is called without size check — the whole content is loaded.
+      // After fix: stat() is called first; size > 512 KB returns null without reading.
+      const result = await system.readMemory('big.md');
+      expect(result).toBeNull();
+    });
   });
 
   describe('deleteMemory', () => {


### PR DESCRIPTION
## Issue
Closes #262

## Problema
`readMemory` em `file-memory-system.ts` chamava `readFile` sem verificar o tamanho do arquivo previamente. Um arquivo de memória artificialmente grande (ex: volume montado externamente) podia esgotar a heap em cada turno, pois `readMemory` é chamado no caminho crítico de `buildFullContext()`.

## Abordagem TDD
- Teste em: `tests/unit/memory/file-memory-system.test.ts` (describe "readMemory", caso "exceeding 512 KB")
- Falha antes do fix (red): `readMemory` retornava o objeto populado mesmo para arquivo > 512 KB
- Implementação mínima em: `src/memory/file-memory-system.ts` — `stat()` movido para antes de `readFile`, retorna `null` se `size > 512 KB`
- Suíte completa: verde (985 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfW22bny5s2JPtVoJNhVL)_