### PR TITLE
fix: normaliza nomes de tools MCP para charset válido [a-zA-Z0-9_-] (closes #263)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -78,6 +78,22 @@ const MCPToolContentSchema = z.array(
     .passthrough(),
 );
 
+/**
+ * Normalizes a string to a valid function-name identifier per the OpenAI spec:
+ * ^[a-zA-Z0-9_-]{1,N}$
+ * Replaces any character outside that set with '_', collapses runs of '_', and
+ * strips leading/trailing '_'. Falls back to 'x' for an empty result.
+ */
+function toSafeIdentifier(raw: string, maxLen = 50): string {
+  return (
+    raw
+      .replace(/[^a-zA-Z0-9_-]/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^_|_$/g, '')
+      .slice(0, maxLen) || 'x'
+  );
+}
+
 /** Sanitizes untrusted MCP text (names/descriptions) before embedding in system prompts. */
 function sanitizeForPrompt(value: string): string {
   return (
@@ -388,8 +404,12 @@ export class MCPAdapter {
     client: MCPClient,
     config: MCPConnectionConfig,
   ): AgentTool {
-    const safeServerName = sanitizeForPrompt(serverName.replace(/__/g, '_')).replace(/\n/g, '');
-    const safeToolName = sanitizeForPrompt(mcpTool.name.replace(/__/g, '_')).replace(/\n/g, '');
+    const safeServerName = toSafeIdentifier(
+      sanitizeForPrompt(serverName.replace(/__/g, '_')).replace(/\n/g, ''),
+    );
+    const safeToolName = toSafeIdentifier(
+      sanitizeForPrompt(mcpTool.name.replace(/__/g, '_')).replace(/\n/g, ''),
+    );
     const namespacedName = `mcp__${safeServerName}__${safeToolName}`;
     const parameters: ZodSchema = jsonSchemaToZod(mcpTool.inputSchema);
     const isolateErrors = config.isolateErrors ?? true;

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -1225,4 +1225,70 @@ describe('MCPAdapter', () => {
       await adapter.disconnect('tag-server');
     });
   });
+
+  describe('tool name charset normalization (issue #263)', () => {
+    it('replaces spaces in server name with underscores so tool name matches ^[a-zA-Z0-9_-]+$', async () => {
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: 'list_files',
+            description: 'list',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ],
+      });
+
+      const tools = await adapter.connect({
+        name: 'my server',
+        transport: 'stdio',
+        command: 'node',
+      });
+
+      const toolName = tools[0]!.name;
+      expect(toolName).toMatch(/^[a-zA-Z0-9_-]+$/);
+      expect(toolName).toBe('mcp__my_server__list_files');
+      await adapter.disconnect('my server');
+    });
+
+    it('replaces dots in server name with underscores so tool name matches ^[a-zA-Z0-9_-]+$', async () => {
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [
+          { name: 'ping', description: 'ping', inputSchema: { type: 'object', properties: {} } },
+        ],
+      });
+
+      const tools = await adapter.connect({
+        name: 'server.prod',
+        transport: 'stdio',
+        command: 'node',
+      });
+
+      const toolName = tools[0]!.name;
+      expect(toolName).toMatch(/^[a-zA-Z0-9_-]+$/);
+      expect(toolName).toBe('mcp__server_prod__ping');
+      await adapter.disconnect('server.prod');
+    });
+
+    it('collapses consecutive underscores in server name after charset normalization', async () => {
+      mockClient.listTools.mockResolvedValueOnce({
+        tools: [
+          { name: 'do_thing', description: 'do', inputSchema: { type: 'object', properties: {} } },
+        ],
+      });
+
+      const tools = await adapter.connect({
+        name: 'my  server',
+        transport: 'stdio',
+        command: 'node',
+      });
+
+      const toolName = tools[0]!.name;
+      expect(toolName).toMatch(/^[a-zA-Z0-9_-]+$/);
+      // double space → double underscore after char replace → collapsed to single '_' in server part
+      // tool name format: mcp__<server>__<tool>; server part must NOT have double underscore
+      const serverPart = toolName.replace(/^mcp__/, '').replace(/__[^_].*$/, '');
+      expect(serverPart).not.toContain('__');
+      await adapter.disconnect('my  server');
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #263

## Problema
`convertTool` em `mcp-adapter.ts` construía o `namespacedName` sem garantir conformidade com o charset `^[a-zA-Z0-9_-]{1,64}$` exigido pela spec OpenAI function calling. Servidores MCP com nome contendo espaços, pontos ou outros caracteres especiais geravam tool names como `mcp__my server__tool`, causando HTTP 400 em providers OpenAI-compatible.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts` (describe "tool name charset normalization (issue #263)")
- Falha antes do fix (red): nomes com espaço e ponto não correspondiam a `/^[a-zA-Z0-9_-]+$/`
- Implementação mínima em: `src/tools/mcp-adapter.ts` — função `toSafeIdentifier` aplicada após `sanitizeForPrompt`, substituindo chars inválidos por `_`, colapsando `_+` e strippando extremidades
- Suíte completa: verde (987 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfW22bny5s2JPtVoJNhVL)_