### PR TITLE
fix: cap de 200 tools por servidor MCP em connect() (closes #264)

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,6 +16,8 @@ const MCPConnectionConfigSchema = z.object({
   maxRetries: z.number().int().min(0).default(3),
   healthCheckInterval: z.number().positive().default(60_000),
   isolateErrors: z.boolean().default(true),
+  /** Maximum number of tools to register from this server. Prevents DoS via tool flooding. */
+  maxTools: z.number().int().positive().optional(),
 });
 
 /** Cost policy — limits per execution and per session */

--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -196,8 +196,12 @@ export class MCPAdapter {
     // List tools from server
     const { tools: mcpTools } = await client.listTools();
 
+    const MAX_TOOLS_PER_SERVER = 200;
+    const toolLimit = config.maxTools ?? MAX_TOOLS_PER_SERVER;
+    const cappedTools = mcpTools.length > toolLimit ? mcpTools.slice(0, toolLimit) : mcpTools;
+
     // Convert MCP tools to AgentTools
-    const agentTools = mcpTools.map((mcpTool) =>
+    const agentTools = cappedTools.map((mcpTool) =>
       this.convertTool(config.name, mcpTool, client, config),
     );
 

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -1225,4 +1225,59 @@ describe('MCPAdapter', () => {
       await adapter.disconnect('tag-server');
     });
   });
+
+  describe('MCP tools cap per server (issue #264)', () => {
+    function makeTool(n: number) {
+      return {
+        name: `tool_${n}`,
+        description: `Tool number ${n}`,
+        inputSchema: { type: 'object', properties: {} },
+      };
+    }
+
+    it('registers at most 200 tools when server returns more (default cap)', async () => {
+      // Simulate a server returning 300 tools — well above the 200 default cap
+      const manyTools = Array.from({ length: 300 }, (_, i) => makeTool(i));
+      mockClient.listTools.mockResolvedValueOnce({ tools: manyTools });
+
+      const tools = await adapter.connect({
+        name: 'bloated-server',
+        transport: 'stdio',
+        command: 'node',
+      });
+
+      expect(tools.length).toBeLessThanOrEqual(200);
+      expect(vi.mocked(executor.register)).toHaveBeenCalledTimes(tools.length);
+      await adapter.disconnect('bloated-server');
+    });
+
+    it('honours a custom maxTools limit from config', async () => {
+      const manyTools = Array.from({ length: 50 }, (_, i) => makeTool(i));
+      mockClient.listTools.mockResolvedValueOnce({ tools: manyTools });
+
+      const tools = await adapter.connect({
+        name: 'capped-server',
+        transport: 'stdio',
+        command: 'node',
+        maxTools: 10,
+      } as never);
+
+      expect(tools.length).toBe(10);
+      await adapter.disconnect('capped-server');
+    });
+
+    it('registers all tools when server returns fewer than the cap', async () => {
+      const fewTools = Array.from({ length: 5 }, (_, i) => makeTool(i));
+      mockClient.listTools.mockResolvedValueOnce({ tools: fewTools });
+
+      const tools = await adapter.connect({
+        name: 'small-server',
+        transport: 'stdio',
+        command: 'node',
+      });
+
+      expect(tools.length).toBe(5);
+      await adapter.disconnect('small-server');
+    });
+  });
 });


### PR DESCRIPTION
## Issue
Closes #264

## Problema
`connect()` em `mcp-adapter.ts` registrava **todas** as tools retornadas por `client.listTools()` sem limite. Um servidor MCP malicioso ou comprometido podia responder com milhares de tools, causando context window overflow (todas as tools são injetadas no system prompt a cada turno) e spike de CPU/memória na fase de conexão.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts` (describe "MCP tools cap per server (issue #264)")
- Falha antes do fix (red): servidor retornando 300 tools → 300 registradas (> 200)
- Implementação mínima em: `src/tools/mcp-adapter.ts` — constante `MAX_TOOLS_PER_SERVER = 200`, `mcpTools.slice(0, toolLimit)` antes de `map`; campo `maxTools` adicionado ao schema `MCPConnectionConfigSchema` em `config.ts` para permitir override por servidor
- Suíte completa: verde (987 testes)

## Mudanças de regras (justificativa)
Adição de campo opcional `maxTools` ao schema `MCPConnectionConfigSchema` — puramente aditiva, backward-compatible.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfW22bny5s2JPtVoJNhVL)_