### PR TITLE
fix: cap de 128 entradas no toolCalls Map em parseSSEStream (closes #265)

### DIFF
--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -321,9 +321,11 @@ export class LLMClient {
 
           // Tool calls (accumulated incrementally)
           if (delta?.tool_calls) {
+            const MAX_TOOL_CALLS = 128;
             for (const tc of delta.tool_calls) {
               const existing = toolCalls.get(tc.index);
               if (!existing) {
+                if (toolCalls.size >= MAX_TOOL_CALLS) continue;
                 const entry = {
                   id: tc.id ?? '',
                   name: tc.function?.name ?? '',

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -514,6 +514,60 @@ describe('LLMClient', () => {
     });
   });
 
+  describe('toolCalls Map cap (issue #265)', () => {
+    it('ignores tool_call chunks with indices beyond 128 to prevent unbounded Map growth', async () => {
+      // Simulate a malformed SSE stream that sends tool calls with indices 0..199
+      // (200 distinct indices, above the 128-entry cap). Without the fix, all 200
+      // entries would be stored in the Map; with the fix, only the first 128 are kept.
+      const chunks: string[] = [];
+      // First chunk: 130 new tool call indices (only first 128 should be stored)
+      for (let i = 0; i < 130; i++) {
+        chunks.push(
+          `data: {"choices":[{"delta":{"tool_calls":[{"index":${i},"id":"id_${i}","function":{"name":"tool_${i}","arguments":""}}]},"index":0}]}`,
+        );
+      }
+      chunks.push('data: {"choices":[{"finish_reason":"tool_calls","index":0}]}');
+      chunks.push('data: [DONE]');
+
+      const sseResponse = createSSEResponse(chunks);
+      mockFetch(sseResponse);
+
+      const yielded: StreamChunk[] = [];
+      for await (const chunk of client.streamChat({
+        messages: [{ role: 'user', content: 'Hi' }],
+      })) {
+        yielded.push(chunk);
+      }
+
+      const toolCallChunks = yielded.filter((c) => c.type === 'tool_call');
+      // Must be capped at ≤ 128, not 130
+      expect(toolCallChunks.length).toBeLessThanOrEqual(128);
+    });
+
+    it('accumulates arguments for tool calls within the cap normally', async () => {
+      // Normal case: 2 tool calls with incremental argument chunks — must still work
+      const sseResponse = createSSEResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_a","function":{"name":"fn_a","arguments":""}}]},"index":0}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"x\\":1}"}}]},"index":0}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_b","function":{"name":"fn_b","arguments":"{\\"y\\":2}"}}]},"index":0}]}',
+        'data: {"choices":[{"finish_reason":"tool_calls","index":0}]}',
+      ]);
+      mockFetch(sseResponse);
+
+      const yielded: StreamChunk[] = [];
+      for await (const chunk of client.streamChat({
+        messages: [{ role: 'user', content: 'Hi' }],
+      })) {
+        yielded.push(chunk);
+      }
+
+      const toolCalls = yielded.filter((c) => c.type === 'tool_call');
+      expect(toolCalls).toHaveLength(2);
+      expect(toolCalls[0]).toMatchObject({ name: 'fn_a', arguments: '{"x":1}' });
+      expect(toolCalls[1]).toMatchObject({ name: 'fn_b', arguments: '{"y":2}' });
+    });
+  });
+
   describe('SSRF protection (issue #113)', () => {
     it('throws when baseUrl points to cloud metadata endpoint (169.254.169.254)', () => {
       expect(

--- a/tests/unit/llm/llm-client.test.ts
+++ b/tests/unit/llm/llm-client.test.ts
@@ -565,6 +565,9 @@ describe('LLMClient', () => {
       expect(toolCalls).toHaveLength(2);
       expect(toolCalls[0]).toMatchObject({ name: 'fn_a', arguments: '{"x":1}' });
       expect(toolCalls[1]).toMatchObject({ name: 'fn_b', arguments: '{"y":2}' });
+    });
+  });
+
   describe('SSE buffer limit (issue #261)', () => {
     it('throws when a single SSE line exceeds 1 MB without a newline', async () => {
       // Simulate a malformed/malicious SSE stream that sends a chunk > 1 MB with no newline,


### PR DESCRIPTION
## Issue
Closes #265

## Problema
O `Map` que acumula tool calls incrementalmente em `parseSSEStream` (`llm-client.ts`) não tinha limite de entradas. Um provider SSE malformado podia enviar chunks com índices crescentes (0, 1, 2, ..., N), fazendo o Map crescer linearmente na heap. Com o fix do buffer SSE (#261) em vigor, este vetor fica coberto — mas a proteção direta no Map é independente e mais específica.

## Abordagem TDD
- Teste em: `tests/unit/llm/llm-client.test.ts` (describe "toolCalls Map cap (issue #265)")
- Falha antes do fix (red): stream com 130 índices distintos gerava 130 tool_call chunks
- Implementação mínima em: `src/llm/llm-client.ts` — constante `MAX_TOOL_CALLS = 128`, guard `if (toolCalls.size >= MAX_TOOL_CALLS) continue` antes de inserir nova entrada
- Suíte completa: verde (986 testes)

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMfW22bny5s2JPtVoJNhVL)_