### PR TITLE
fix: bloqueia caminhos sensíveis em AGENT_MEMORY_DIR (closes #271)

### DIFF
--- a/src/memory/memory-paths.ts
+++ b/src/memory/memory-paths.ts
@@ -27,12 +27,34 @@ export function getDefaultMemoryDir(): string {
  * Config paths support ~/ expansion (user-friendly).
  * Env var paths must be absolute (set programmatically).
  */
+const BLOCKED_PATH_PREFIXES = [
+  '/etc',
+  '/proc',
+  '/sys',
+  '/dev',
+  '/boot',
+  '/bin',
+  '/sbin',
+  '/usr/bin',
+  '/usr/sbin',
+  '/run',
+  '/var/run',
+  '/tmp',
+];
+
+function isSensitivePath(normalizedPath: string): boolean {
+  const withSep = normalizedPath.endsWith(sep) ? normalizedPath : normalizedPath + sep;
+  return BLOCKED_PATH_PREFIXES.some(
+    (blocked) => withSep.startsWith(blocked + sep) || normalizedPath === blocked,
+  );
+}
+
 export function resolveMemoryDir(memoryDir?: string): string {
   // Env var: no tilde expansion (must be absolute)
   if (!memoryDir && process.env.AGENT_MEMORY_DIR) {
     const envPath = process.env.AGENT_MEMORY_DIR;
     const normalized = normalize(envPath).replace(/[/\\]+$/, '');
-    if (isAbsolute(normalized) && normalized.length >= 3) {
+    if (isAbsolute(normalized) && normalized.length >= 3 && !isSensitivePath(normalized)) {
       return (normalized + sep).normalize('NFC');
     }
   }

--- a/tests/unit/memory/memory-paths.test.ts
+++ b/tests/unit/memory/memory-paths.test.ts
@@ -50,6 +50,56 @@ describe('memory-paths', () => {
       expect(result).not.toContain('~');
       expect(result).toContain('my-memory');
     });
+
+    // Issue #271: AGENT_MEMORY_DIR should reject sensitive system paths
+    it('should reject /etc via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/etc';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/etc');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should reject /proc via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/proc';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/proc');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should reject /sys via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/sys';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/sys');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should reject /dev via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/dev';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/dev');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should reject /bin via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/bin';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/bin');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should reject /tmp via AGENT_MEMORY_DIR and fall back to default', () => {
+      process.env.AGENT_MEMORY_DIR = '/tmp';
+      const result = resolveMemoryDir();
+      expect(result).not.toContain('/tmp');
+      expect(result).toContain('.agentx');
+    });
+
+    it('should still accept a valid absolute path via AGENT_MEMORY_DIR', () => {
+      process.env.AGENT_MEMORY_DIR = '/home/user/projects/myapp/memory';
+      const result = resolveMemoryDir();
+      expect(result).toContain('myapp');
+      expect(result).toContain('memory');
+    });
   });
 
   describe('validateMemoryPath', () => {


### PR DESCRIPTION
## Issue
Closes #271

## Problema
`resolveMemoryDir` aceitava qualquer caminho absoluto em `AGENT_MEMORY_DIR` com comprimento >= 3, incluindo caminhos sensíveis como `/etc`, `/proc`, `/tmp`, `/bin` e outros diretórios do sistema. Um processo comprometido ou configuração indevida poderia direcionar o agente para criar/ler arquivos `.md` nesses diretórios.

## Abordagem TDD
- Teste em: `tests/unit/memory/memory-paths.test.ts`
- Falha antes do fix (red): 6 testes novos falhavam — `/etc`, `/proc`, `/sys`, `/dev`, `/bin`, `/tmp` eram aceitos sem rejeição
- Implementação mínima em: `src/memory/memory-paths.ts` — adicionada `BLOCKED_PATH_PREFIXES` e `isSensitivePath()` na validação do env var
- Suíte completa: 82 arquivos, 991 testes, tudo verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WyZXL6dpSiiULn4yNehHi)_