### PR TITLE
fix: size check em buildContextPrompt antes de ler MEMORY.md (closes #272)

### DIFF
--- a/src/memory/file-memory-system.ts
+++ b/src/memory/file-memory-system.ts
@@ -245,7 +245,7 @@ export class FileMemorySystem {
 
     // Global MEMORY.md
     try {
-      const globalContent = await readFile(join(this.memoryDir, ENTRYPOINT_NAME), 'utf-8');
+      const globalContent = await safeReadIndexFile(join(this.memoryDir, ENTRYPOINT_NAME));
       if (globalContent.trim()) parts.push(globalContent.trim());
     } catch {
       /* no global index */
@@ -254,9 +254,8 @@ export class FileMemorySystem {
     // Thread MEMORY.md
     if (threadId) {
       try {
-        const threadContent = await readFile(
+        const threadContent = await safeReadIndexFile(
           join(this.resolveDir(threadId), ENTRYPOINT_NAME),
-          'utf-8',
         );
         if (threadContent.trim()) parts.push(threadContent.trim());
       } catch {
@@ -397,6 +396,18 @@ export class FileMemorySystem {
       },
     );
     return result;
+  }
+}
+
+const MAX_INDEX_FILE_BYTES = 512 * 1024;
+
+async function safeReadIndexFile(filePath: string): Promise<string> {
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.size > MAX_INDEX_FILE_BYTES) return '';
+    return await readFile(filePath, 'utf-8');
+  } catch {
+    return '';
   }
 }
 

--- a/tests/unit/memory/file-memory-system.test.ts
+++ b/tests/unit/memory/file-memory-system.test.ts
@@ -202,6 +202,34 @@ describe('FileMemorySystem', () => {
       const result = await system.buildContextPrompt();
       expect(result).toBe('');
     });
+
+    // Issue #272: buildContextPrompt must not load oversized MEMORY.md into heap
+    it('should skip global MEMORY.md when file exceeds 512 KB', async () => {
+      const oversized = Buffer.alloc(513 * 1024, '-').toString();
+      await writeFile(join(tempDir, 'MEMORY.md'), oversized);
+
+      const result = await system.buildContextPrompt();
+      expect(result).toBe('');
+    });
+
+    it('should skip thread MEMORY.md when file exceeds 512 KB', async () => {
+      const { mkdir } = await import('node:fs/promises');
+      const threadDir = join(tempDir, 'threads', 'mythread');
+      await mkdir(threadDir, { recursive: true });
+      const oversized = Buffer.alloc(513 * 1024, '-').toString();
+      await writeFile(join(threadDir, 'MEMORY.md'), oversized);
+
+      const result = await system.buildContextPrompt('mythread');
+      expect(result).toBe('');
+    });
+
+    it('should still return content when MEMORY.md is within 512 KB', async () => {
+      const content = '- [Test](test.md) — within limit\n';
+      await writeFile(join(tempDir, 'MEMORY.md'), content);
+
+      const result = await system.buildContextPrompt();
+      expect(result).toContain('within limit');
+    });
   });
 
   describe('buildFullContext', () => {


### PR DESCRIPTION
## Issue
Closes #272

## Problema
`buildContextPrompt` chamava `readFile` diretamente nos arquivos `MEMORY.md` (global e de thread) sem verificar tamanho previamente. Um arquivo de índice artificialmente grande poderia exaurir a heap a cada turno da conversa (o método é chamado em `buildFullContext` a cada mensagem).

## Abordagem TDD
- Teste em: `tests/unit/memory/file-memory-system.test.ts`
- Falha antes do fix (red): testes com MEMORY.md de 513 KB retornavam o conteúdo completo em vez de string vazia
- Implementação mínima em: `src/memory/file-memory-system.ts` — adicionada `safeReadIndexFile()` com `stat()` + limite de 512 KB substituindo `readFile` direto em `buildContextPrompt`
- Suíte completa: 82 arquivos, 987 testes, tudo verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WyZXL6dpSiiULn4yNehHi)_