### PR TITLE
fix: scanMemoryFiles não segue symlinks durante travessia (closes #273)

### DIFF
--- a/src/memory/memory-scanner.ts
+++ b/src/memory/memory-scanner.ts
@@ -4,7 +4,7 @@
  */
 
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { basename, join, sep } from 'node:path';
 import {
   type MemoryHeader,
   type MemoryFrontmatter,
@@ -14,6 +14,21 @@ import {
 } from './memory-types.js';
 
 const FRONTMATTER_MAX_LINES = 30;
+
+async function readdirNoFollow(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      const sub = await readdirNoFollow(join(dir, entry.name));
+      results.push(...sub.map((f) => entry.name + sep + f));
+    } else {
+      results.push(entry.name);
+    }
+  }
+  return results;
+}
 
 /**
  * Parse YAML frontmatter from markdown content.
@@ -65,11 +80,12 @@ export async function scanMemoryFiles(
 ): Promise<MemoryHeader[]> {
   try {
     if (signal?.aborted) return [];
-    const entries = await readdir(memoryDir, { recursive: true });
+    const entries = await readdirNoFollow(memoryDir);
     const mdFiles = entries.filter(
       (f) =>
         f.endsWith('.md') &&
         basename(f) !== ENTRYPOINT_NAME &&
+        !f.startsWith('threads' + sep) &&
         !f.startsWith('threads/') &&
         !f.startsWith('threads\\'),
     );

--- a/tests/unit/memory/memory-scanner.test.ts
+++ b/tests/unit/memory/memory-scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -203,6 +203,55 @@ Content here`,
 
     it('should return empty string for empty array', () => {
       expect(formatMemoryManifest([])).toBe('');
+    });
+  });
+
+  // Issue #273: scanMemoryFiles must not follow symlinks during traversal
+  describe('scanMemoryFiles — symlink safety', () => {
+    let tempDir: string;
+    let externalDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'scanner-symlink-'));
+      externalDir = await mkdtemp(join(tmpdir(), 'scanner-external-'));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+      await rm(externalDir, { recursive: true, force: true });
+    });
+
+    it('should not enumerate .md files inside a symlinked directory', async () => {
+      // Real file inside memoryDir — should appear in results
+      await writeFile(join(tempDir, 'real.md'), '---\nname: Real\ntype: user\n---\n');
+
+      // .md file in the external directory — must NOT appear in results
+      await writeFile(join(externalDir, 'leaked.md'), '---\nname: Leaked\ntype: user\n---\n');
+
+      // Symlink inside memoryDir pointing to external directory
+      await symlink(externalDir, join(tempDir, 'escape-link'));
+
+      const result = await scanMemoryFiles(tempDir);
+      const filenames = result.map((m) => m.filename);
+
+      expect(filenames).toContain('real.md');
+      expect(filenames.some((f) => f.includes('leaked.md'))).toBe(false);
+    });
+
+    it('should not enumerate .md files inside a nested symlinked directory', async () => {
+      const subDir = join(tempDir, 'sub');
+      await mkdir(subDir, { recursive: true });
+      await writeFile(join(subDir, 'inner.md'), '---\nname: Inner\ntype: user\n---\n');
+
+      // Symlink inside a subdirectory
+      await writeFile(join(externalDir, 'outside.md'), '---\nname: Outside\ntype: user\n---\n');
+      await symlink(externalDir, join(subDir, 'escape-nested'));
+
+      const result = await scanMemoryFiles(tempDir);
+      const filenames = result.map((m) => m.filename);
+
+      expect(filenames.some((f) => f.includes('inner.md'))).toBe(true);
+      expect(filenames.some((f) => f.includes('outside.md'))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Issue
Closes #273

## Problema
`scanMemoryFiles` usava `readdir(memoryDir, { recursive: true })`, que no Node.js segue symlinks de diretório durante a travessia. Um symlink dentro de `memoryDir` apontando para um diretório externo (ex.: `/etc`) resultava em enumeração de nomes de arquivos externos no manifest enviado ao LLM (information leak), além de risco de DoS por travessia de árvore muito grande.

## Abordagem TDD
- Teste em: `tests/unit/memory/memory-scanner.test.ts`
- Falha antes do fix (red): testes com symlinks de diretório mostravam arquivos do diretório externo no resultado
- Implementação mínima em: `src/memory/memory-scanner.ts` — substituída chamada `readdir({ recursive: true })` por `readdirNoFollow()`, travessia manual com `withFileTypes: true` que pula entradas `isSymbolicLink()`
- Suíte completa: 82 arquivos, 986 testes, tudo verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WyZXL6dpSiiULn4yNehHi)_