### PR TITLE
fix: previne prototype pollution em MCPAdapter.getPrompt (closes #274)

### DIFF
--- a/src/tools/mcp-adapter.ts
+++ b/src/tools/mcp-adapter.ts
@@ -348,11 +348,16 @@ export class MCPAdapter {
       throw new Error(`MCP server "${serverName}" not connected`);
     }
 
-    const parsedArgs: Record<string, string> = {};
+    const parsedArgs = Object.create(null) as Record<string, string>;
     if (args) {
+      const SAFE_KEY_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+      const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
       for (const part of args.split(/\s+/)) {
-        const [k, ...v] = part.split('=');
-        if (k && v.length > 0) parsedArgs[k] = v.join('=');
+        const eqIdx = part.indexOf('=');
+        if (eqIdx <= 0) continue;
+        const k = part.slice(0, eqIdx);
+        const v = part.slice(eqIdx + 1);
+        if (SAFE_KEY_RE.test(k) && !BLOCKED_KEYS.has(k)) parsedArgs[k] = v;
       }
     }
 

--- a/tests/unit/tools/mcp-adapter.test.ts
+++ b/tests/unit/tools/mcp-adapter.test.ts
@@ -701,6 +701,53 @@ describe('MCPAdapter', () => {
 
       delete (mockClient as Record<string, unknown>).getPrompt;
     });
+
+    // Issue #274: prototype pollution via unsanitized key in getPrompt args parsing
+    it('should filter out __proto__ key from parsed args', async () => {
+      const getPromptFn = vi.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: 'ok' }],
+      });
+      (mockClient as Record<string, unknown>).getPrompt = getPromptFn;
+
+      await adapter.connect({ name: 'proto-srv', transport: 'stdio', command: 'node' });
+      await adapter.getPrompt('proto-srv', 'p', '__proto__=danger foo=bar');
+
+      const call = getPromptFn.mock.calls[0][0] as { arguments: Record<string, string> };
+      expect(Object.prototype.hasOwnProperty.call(call.arguments, '__proto__')).toBe(false);
+      expect(call.arguments.foo).toBe('bar');
+
+      delete (mockClient as Record<string, unknown>).getPrompt;
+    });
+
+    it('should filter out constructor key from parsed args', async () => {
+      const getPromptFn = vi.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: 'ok' }],
+      });
+      (mockClient as Record<string, unknown>).getPrompt = getPromptFn;
+
+      await adapter.connect({ name: 'ctor-srv', transport: 'stdio', command: 'node' });
+      await adapter.getPrompt('ctor-srv', 'p', 'constructor=danger name=Alice');
+
+      const call = getPromptFn.mock.calls[0][0] as { arguments: Record<string, string> };
+      expect(Object.prototype.hasOwnProperty.call(call.arguments, 'constructor')).toBe(false);
+      expect(call.arguments.name).toBe('Alice');
+
+      delete (mockClient as Record<string, unknown>).getPrompt;
+    });
+
+    it('should not pollute Object.prototype when __proto__ key is in args', async () => {
+      const getPromptFn = vi.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: 'ok' }],
+      });
+      (mockClient as Record<string, unknown>).getPrompt = getPromptFn;
+
+      await adapter.connect({ name: 'no-pollute-srv', transport: 'stdio', command: 'node' });
+      await adapter.getPrompt('no-pollute-srv', 'p', '__proto__[isAdmin]=true');
+
+      expect(({} as Record<string, unknown>).isAdmin).toBeUndefined();
+
+      delete (mockClient as Record<string, unknown>).getPrompt;
+    });
   });
 
   describe('Zod validation of server responses (issue #28)', () => {


### PR DESCRIPTION
## Issue
Closes #274

## Problema
O método `getPrompt` construía `parsedArgs` como `{}` e atribuía chaves arbitrárias de input do usuário sem sanitização. Chaves como `__proto__`, `constructor` e `prototype` eram passadas diretamente ao servidor MCP, podendo causar comportamento indefinido dependendo de como o servidor as processa.

## Abordagem TDD
- Teste em: `tests/unit/tools/mcp-adapter.test.ts`
- Falha antes do fix (red): teste de `constructor=danger` confirmava que a chave era passada ao servidor (hasOwnProperty retornava true)
- Implementação mínima em: `src/tools/mcp-adapter.ts`:
  - `Object.create(null)` como base de `parsedArgs` — elimina herança de protótipo
  - `SAFE_KEY_RE = /^[a-zA-Z0-9_-]{1,64}$/` — valida formato da chave
  - `BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype'])` — bloqueia chaves explicitamente perigosas
- Suíte completa: 82 arquivos, 987 testes, tudo verde

## Mudanças de regras (justificativa)
Nenhuma.

## Checklist
- [x] Teste antes do fix
- [x] Suíte verde
- [x] Sem mudança de regras existentes (ou justificada)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WyZXL6dpSiiULn4yNehHi)_