### PR TITLE
fix(security): remove TOCTOU race in safeReadIndexFile (CodeQL js/file-system-race)

### DIFF
--- a/src/memory/file-memory-system.ts
+++ b/src/memory/file-memory-system.ts
@@ -18,7 +18,7 @@
  *         ...
  */
 
-import { readFile, writeFile, unlink, stat, readdir, mkdir } from 'node:fs/promises';
+import { open, readFile, writeFile, unlink, stat, readdir, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { LLMClient } from '../llm/llm-client.js';
 import type { Logger } from '../utils/logger.js';
@@ -402,12 +402,20 @@ export class FileMemorySystem {
 const MAX_INDEX_FILE_BYTES = 512 * 1024;
 
 async function safeReadIndexFile(filePath: string): Promise<string> {
+  // Open once and stat+read through the same descriptor to avoid a TOCTOU
+  // race (js/file-system-race) between the size check and the read.
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    const fileStat = await stat(filePath);
+    handle = await open(filePath, 'r');
+    const fileStat = await handle.stat();
     if (fileStat.size > MAX_INDEX_FILE_BYTES) return '';
-    return await readFile(filePath, 'utf-8');
+    const buffer = Buffer.alloc(fileStat.size);
+    await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.toString('utf-8');
   } catch {
     return '';
+  } finally {
+    await handle?.close();
   }
 }
 


### PR DESCRIPTION
## Diagnóstico

CodeQL falha no PR #276 com 1 alerta **HIGH**: race condition TOCTOU (`js/file-system-race`) em `src/memory/file-memory-system.ts`. `safeReadIndexFile` faz `stat()` (size guard) e depois `readFile()` em paths separados — janela entre check e read permite que o arquivo cresça/mude entre as duas chamadas.

Run que falhou: https://github.com/DouglasPrado/agentx-sdk/runs/76395475861

## Categoria

`código` (security-adjacent: file system)

## Confiança

92%

## O que mudou

Abre o arquivo **uma vez** via `fs/promises.open()` e faz `stat()` + `read()` pelo **mesmo file descriptor**, eliminando a janela check-then-read. Buffer alocado com tamanho exato do `stat` (já limitado a 512 KB pelo guard antes do `alloc`). fd fechado em `finally`. Comportamento inalterado: index > 512 KB ainda retorna `''`.

```ts
handle = await open(filePath, 'r');
const fileStat = await handle.stat();
if (fileStat.size > MAX_INDEX_FILE_BYTES) return '';
const buffer = Buffer.alloc(fileStat.size);
await handle.read(buffer, 0, buffer.length, 0);
```

## Validação

- `pnpm typecheck` ✓
- `pnpm test` ✓ 987/987
- `/security-review` ✓ — sem issues HIGH/CRITICAL (fix é puramente defensivo, remove a race)

## Notas

PR stacked sobre a branch do #276 (base = `fix/issue-272-context-prompt-size-check`). Merge deste PR no #276 faz o CodeQL passar. Mesmo padrão TOCTOU existe em #267 (`readMemory`) e #246 (`loadSkillFile`) — mesmo fix se aplica.