### PR TITLE
fix(security): remove TOCTOU race in loadSkillFile (CodeQL js/file-system-race)

### DIFF
--- a/src/skills/skill-loader.ts
+++ b/src/skills/skill-loader.ts
@@ -9,7 +9,7 @@
  *   skillsDir/skill-name.md           (flat — single file per skill)
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { open, readdir, stat } from 'node:fs/promises';
 import { join, basename, dirname } from 'node:path';
 import type { AgentSkill } from '../contracts/entities/agent-skill.js';
 import { substituteArgs } from './skill-args.js';
@@ -119,10 +119,16 @@ export function extractBody(content: string): string {
 const MAX_SKILL_FILE_BYTES = 512 * 1024; // 512 KB
 
 export async function loadSkillFile(filePath: string): Promise<AgentSkill | null> {
+  // Open once and stat+read through the same descriptor to avoid a TOCTOU
+  // race (js/file-system-race) between the size check and the read.
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    const fileInfo = await stat(filePath);
+    handle = await open(filePath, 'r');
+    const fileInfo = await handle.stat();
     if (fileInfo.size > MAX_SKILL_FILE_BYTES) return null;
-    const content = await readFile(filePath, 'utf-8');
+    const buffer = Buffer.alloc(fileInfo.size);
+    await handle.read(buffer, 0, buffer.length, 0);
+    const content = buffer.toString('utf-8');
     const fm = parseSkillFrontmatter(content);
     const body = extractBody(content);
 
@@ -169,6 +175,8 @@ export async function loadSkillFile(filePath: string): Promise<AgentSkill | null
     return skill;
   } catch {
     return null;
+  } finally {
+    await handle?.close();
   }
 }
 


### PR DESCRIPTION
## Diagnóstico

CodeQL falha no PR #246 com 1 alerta **HIGH**: race condition TOCTOU (`js/file-system-race`) em `src/skills/skill-loader.ts:125` (`loadSkillFile`). `stat()` (size guard) seguido de `readFile()` em paths separados — janela check-then-read.

Run que falhou: https://github.com/DouglasPrado/agentx-sdk/runs/75787638729

## Categoria

`código` (security-adjacent: file system)

## Confiança

92%

## O que mudou

Abre o SKILL.md **uma vez** via `fs/promises.open()` e faz `stat()` + `read()` pelo **mesmo file descriptor**, eliminando a janela TOCTOU. Buffer alocado com tamanho exato do `handle.stat()` (limitado a 512 KB pelo guard antes do `alloc`). fd fechado em `finally`. Import `readFile` removido (não mais usado). Comportamento inalterado: arquivo > 512 KB retorna null.

## Validação

- `tests/unit/skills/skill-loader.test.ts` ✓ 23/23
- Sem type errors introduzidos em skill-loader.ts (typecheck local desta branch já tem erros pré-existentes de zod drift em `sql-tool-factory.ts`/`tool-executor.ts`, presentes no base — `zod-to-json-schema` not found; CI do PR 246 passa typecheck/build normalmente, falha só em Audit+CodeQL)
- `/security-review` ✓ — sem issues HIGH/CRITICAL (mesmo padrão defensivo auditado em #330 e #331)

## Notas

Stacked sobre a branch do #246 (base = `fix/issue-240-skill-file-size-limit`). Resolve o CodeQL. A outra falha vermelha do #246 (`quality`/Audit dependencies = hono CVE GHSA-88fw-hqm2-52qc) é sistêmica — já coberta pelos PRs #325/#326.